### PR TITLE
Better MySQL < 5.7.7 and MariaDB < 10.2.2 support

### DIFF
--- a/phpunit.mariadb.xml
+++ b/phpunit.mariadb.xml
@@ -16,6 +16,7 @@
         <var name="db_password" value=""/>
         <var name="db_name" value="auditor"/>
         <var name="db_port" value="3306"/>
+        <var name="db_charset" value="utf8mb4"/>
     </php>
 
     <testsuites>

--- a/phpunit.mysql.xml
+++ b/phpunit.mysql.xml
@@ -16,6 +16,7 @@
         <var name="db_password" value=""/>
         <var name="db_name" value="auditor"/>
         <var name="db_port" value="3306"/>
+        <var name="db_charset" value="utf8mb4"/>
     </php>
 
     <testsuites>

--- a/phpunit.pgsql.xml
+++ b/phpunit.pgsql.xml
@@ -16,6 +16,7 @@
         <var name="db_password" value="password"/>
         <var name="db_name" value="auditor"/>
         <var name="db_port" value="5432"/>
+        <var name="db_charset" value="utf8"/>
     </php>
 
     <testsuites>

--- a/tests/Provider/Doctrine/Fixtures/Issue37/User.php
+++ b/tests/Provider/Doctrine/Fixtures/Issue37/User.php
@@ -23,7 +23,7 @@ class User
     protected $username;
 
     /**
-     * @ORM\Column(type="string", nullable=true)
+     * @ORM\Column(type="string", nullable=true, length=5)
      */
     protected $locale_id;
 

--- a/tests/Provider/Doctrine/Persistence/Schema/SchemaManagerTest.php
+++ b/tests/Provider/Doctrine/Persistence/Schema/SchemaManagerTest.php
@@ -188,7 +188,7 @@ final class SchemaManagerTest extends TestCase
         $reflectedMethod->invokeArgs($updater, [$table, $columns, $alternateColumns]);
 
         $reflectedMethod = $this->reflectMethod($updater, 'processIndices');
-        $reflectedMethod->invokeArgs($updater, [$table, $alternateIndices]);
+        $reflectedMethod->invokeArgs($updater, [$table, $alternateIndices, $entityManager->getConnection()]);
 
         $this->migrate($fromSchema, $toSchema, $entityManager, $schemaManager->getDatabasePlatform(), true);
 

--- a/tests/Provider/Doctrine/Persistence/Schema/SchemaManagerTest.php
+++ b/tests/Provider/Doctrine/Persistence/Schema/SchemaManagerTest.php
@@ -109,6 +109,13 @@ final class SchemaManagerTest extends TestCase
                     'length' => 50,
                 ],
             ],
+            'discriminator' => [
+                'type' => Types::STRING,
+                'options' => [
+                    'default' => null,
+                    'notnull' => false,
+                ],
+            ],
             'diffs' => [
                 'type' => Types::JSON_ARRAY,
                 'options' => [

--- a/tests/Provider/Doctrine/Traits/ConnectionTrait.php
+++ b/tests/Provider/Doctrine/Traits/ConnectionTrait.php
@@ -94,7 +94,7 @@ trait ConnectionTrait
             'host' => $GLOBALS['db_host'],
             'dbname' => $GLOBALS['db_name'],
             'port' => $GLOBALS['db_port'],
-            'charset' => 'utf8mb4',
+            'charset' => $GLOBALS['db_charset'],
         ];
     }
 }

--- a/tests/Provider/Doctrine/Traits/ConnectionTrait.php
+++ b/tests/Provider/Doctrine/Traits/ConnectionTrait.php
@@ -94,6 +94,7 @@ trait ConnectionTrait
             'host' => $GLOBALS['db_host'],
             'dbname' => $GLOBALS['db_name'],
             'port' => $GLOBALS['db_port'],
+            'charset' => 'utf8mb4',
         ];
     }
 }


### PR DESCRIPTION
Specify an index length of 191 to indexed string columns of over 191 chars when using MySQL < 5.7.7 or MariaDB < 10.2.2 - Fixes [auditor-bundle #178](https://github.com/DamienHarper/auditor-bundle/issues/178)