### PR TITLE
Supports MariaDB with no JSON support

### DIFF
--- a/src/Provider/Doctrine/Persistence/Schema/SchemaManager.php
+++ b/src/Provider/Doctrine/Persistence/Schema/SchemaManager.php
@@ -319,21 +319,96 @@ class SchemaManager
             return false;
         }
 
-        $wrappedConnection = $connection->getWrappedConnection();
+        $version = $this->getServerVersion($connection);
 
-        if ($wrappedConnection instanceof ServerInfoAwareConnection) {
-            $version = $wrappedConnection->getServerVersion();
+        if (null === $version) {
+            return false;
+        }
 
-            $mariadb = false !== mb_stripos($version, 'mariadb');
-            if ($mariadb && version_compare($version, '10.2.2', '<')) {
-                return true;
-            }
+        $mariadb = false !== mb_stripos($version, 'mariadb');
+        if ($mariadb && version_compare($this->getMariaDbMysqlVersionNumber($version), '10.2.2', '<')) {
+            return true;
+        }
 
-            if (!$mariadb && version_compare($version, '5.7.7', '<')) {
-                return true;
-            }
+        if (!$mariadb && version_compare($this->getOracleMysqlVersionNumber($version), '5.7.7', '<')) {
+            return true;
         }
 
         return false;
+    }
+
+    private function getServerVersion(Connection $connection): ?string
+    {
+        $wrappedConnection = $connection->getWrappedConnection();
+
+        if ($wrappedConnection instanceof ServerInfoAwareConnection) {
+            return $wrappedConnection->getServerVersion();
+        }
+
+        return null;
+    }
+
+    private function isJsonSupported(Connection $connection): bool
+    {
+        $version = $this->getServerVersion($connection);
+        if (null === $version) {
+            return true;
+        }
+
+        $mariadb = false !== mb_stripos($version, 'mariadb');
+        if ($mariadb && version_compare($this->getMariaDbMysqlVersionNumber($version), '10.2.7', '<')) {
+            // JSON wasn't supported on MariaDB before 10.2.7
+            // @see https://mariadb.com/kb/en/json-data-type/
+            return false;
+        }
+
+        // Assume JSON is supported
+        return true;
+    }
+
+    /**
+     * Get a normalized 'version number' from the server string
+     * returned by Oracle MySQL servers.
+     *
+     * @param string $versionString Version string returned by the driver, i.e. '5.7.10'
+     *
+     * @copyright Doctrine team
+     */
+    private function getOracleMysqlVersionNumber(string $versionString): string
+    {
+        preg_match(
+            '/^(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?)?/',
+            $versionString,
+            $versionParts
+        );
+
+        $majorVersion = $versionParts['major'];
+        $minorVersion = $versionParts['minor'] ?? 0;
+        $patchVersion = $versionParts['patch'] ?? null;
+
+        if ('5' === $majorVersion && '7' === $minorVersion && null === $patchVersion) {
+            $patchVersion = '9';
+        }
+
+        return $majorVersion.'.'.$minorVersion.'.'.$patchVersion;
+    }
+
+    /**
+     * Detect MariaDB server version, including hack for some mariadb distributions
+     * that starts with the prefix '5.5.5-'.
+     *
+     * @param string $versionString Version string as returned by mariadb server, i.e. '5.5.5-Mariadb-10.0.8-xenial'
+     *
+     * @copyright Doctrine team
+     */
+    private function getMariaDbMysqlVersionNumber(string $versionString): string
+    {
+        preg_match(
+            '/^(?:5\.5\.5-)?(mariadb-)?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)/i',
+            $versionString,
+            $versionParts
+        );
+
+        return $versionParts['major'].'.'.$versionParts['minor'].'.'.$versionParts['patch'];
     }
 }

--- a/tests/Provider/Doctrine/Persistence/Schema/SchemaManagerTest.php
+++ b/tests/Provider/Doctrine/Persistence/Schema/SchemaManagerTest.php
@@ -117,7 +117,7 @@ final class SchemaManagerTest extends TestCase
                 ],
             ],
             'diffs' => [
-                'type' => Types::JSON_ARRAY,
+                'type' => Types::JSON,
                 'options' => [
                     'default' => null,
                     'notnull' => false,

--- a/tests/Provider/Doctrine/Persistence/Schema/SchemaManagerTest.php
+++ b/tests/Provider/Doctrine/Persistence/Schema/SchemaManagerTest.php
@@ -192,7 +192,7 @@ final class SchemaManagerTest extends TestCase
         $columns = $schemaManager->listTableColumns($authorAuditTable->getName());
 
         $reflectedMethod = $this->reflectMethod($updater, 'processColumns');
-        $reflectedMethod->invokeArgs($updater, [$table, $columns, $alternateColumns]);
+        $reflectedMethod->invokeArgs($updater, [$table, $columns, $alternateColumns, $entityManager->getConnection()]);
 
         $reflectedMethod = $this->reflectMethod($updater, 'processIndices');
         $reflectedMethod->invokeArgs($updater, [$table, $alternateIndices, $entityManager->getConnection()]);


### PR DESCRIPTION
Use `TEXT` type instead of `JSON` when using an old version of MariaDB which so not support JSON.
Also fixes MySQL and MariaDB version detection.

Fixes [auditor-bundle #195](https://github.com/DamienHarper/auditor-bundle/issues/195)