### PR TITLE
Query filters

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -21,3 +21,6 @@ parameters:
         - '~Cannot call method setFetchMode\(\) on Doctrine\\DBAL\\Driver\\ResultStatement\|int~'
         - '~Cannot call method fetchAll\(\) on Doctrine\\DBAL\\Driver\\ResultStatement\|int~'
         - '~Parameter \#1 \$keep of method DH\\Auditor\\Provider\\Doctrine\\Persistence\\Command\\CleanAuditLogsCommand\:\:validateKeepArgument\(\) expects string, string\|null given~'
+        - '~Method DH\\Auditor\\Provider\\Doctrine\\Persistence\\Reader\\Filter\\RangeFilter\:\:__construct\(\) has parameter \$minValue with no typehint specified~'
+        - '~Method DH\\Auditor\\Provider\\Doctrine\\Persistence\\Reader\\Filter\\RangeFilter\:\:__construct\(\) has parameter \$maxValue with no typehint specified~'
+        - '~Method DH\\Auditor\\Provider\\Doctrine\\Persistence\\Reader\\Filter\\\SimpleFilter\:\:__construct\(\) has parameter \$value with no typehint specified.~'

--- a/src/Provider/Doctrine/Persistence/Reader/Filter/DateRangeFilter.php
+++ b/src/Provider/Doctrine/Persistence/Reader/Filter/DateRangeFilter.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter;
+
+use DateTime;
+use DH\Auditor\Exception\InvalidArgumentException;
+
+class DateRangeFilter extends RangeFilter
+{
+    public function __construct(string $name, ?DateTime $minValue, ?DateTime $maxValue = null)
+    {
+        parent::__construct($name, $minValue, $maxValue);
+
+        if (null !== $minValue && null !== $maxValue && $minValue > $maxValue) {
+            throw new InvalidArgumentException('Max bound has to be later than min bound.');
+        }
+
+//        $this->filters[$name][] = [
+//            null === $minValue ? null : $minValue->format('Y-m-d H:i:s'),
+//            null === $maxValue ? null : $maxValue->format('Y-m-d H:i:s'),
+//        ];
+    }
+
+    /**
+     * @return DateTime
+     */
+    public function getMinValue(): ?DateTime
+    {
+        return $this->minValue;
+    }
+
+    /**
+     * @return DateTime
+     */
+    public function getMaxValue(): ?DateTime
+    {
+        return $this->maxValue;
+    }
+
+    public function getSQL(): array
+    {
+        $sqls = [];
+        $params = [];
+
+        if (null !== $this->minValue) {
+            $sqls[] = sprintf('%s >= :min_%s', $this->name, $this->name);
+            $params['min_'.$this->name] = $this->minValue->format('Y-m-d H:i:s');
+        }
+
+        if (null !== $this->maxValue) {
+            $sqls[] = sprintf('%s <= :max_%s', $this->name, $this->name);
+            $params['max_'.$this->name] = $this->maxValue->format('Y-m-d H:i:s');
+        }
+
+        return [
+            'sql' => implode(' AND ', $sqls),
+            'params' => $params,
+        ];
+    }
+}

--- a/src/Provider/Doctrine/Persistence/Reader/Filter/FilterInterface.php
+++ b/src/Provider/Doctrine/Persistence/Reader/Filter/FilterInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter;
+
+interface FilterInterface
+{
+    public function getName(): string;
+
+    public function getSQL(): array;
+}

--- a/src/Provider/Doctrine/Persistence/Reader/Filter/RangeFilter.php
+++ b/src/Provider/Doctrine/Persistence/Reader/Filter/RangeFilter.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter;
+
+use DH\Auditor\Exception\InvalidArgumentException;
+
+class RangeFilter implements FilterInterface
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var mixed
+     */
+    protected $minValue;
+
+    /**
+     * @var mixed
+     */
+    protected $maxValue;
+
+    public function __construct(string $name, $minValue, $maxValue = null)
+    {
+        if (null === $minValue && null === $maxValue) {
+            throw new InvalidArgumentException('You must provide at least one of the two range bounds.');
+        }
+
+        $this->name = $name;
+        $this->minValue = $minValue;
+        $this->maxValue = $maxValue;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getMinValue()
+    {
+        return $this->minValue;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getMaxValue()
+    {
+        return $this->maxValue;
+    }
+
+    public function getSQL(): array
+    {
+        $sqls = [];
+        $params = [];
+
+        if (null !== $this->minValue) {
+            $sqls[] = sprintf('%s >= :min_%s', $this->name, $this->name);
+            $params['min_'.$this->name] = $this->minValue;
+        }
+
+        if (null !== $this->maxValue) {
+            $sqls[] = sprintf('%s <= :max_%s', $this->name, $this->name);
+            $params['max_'.$this->name] = $this->maxValue;
+        }
+
+        return [
+            'sql' => implode(' AND ', $sqls),
+            'params' => $params,
+        ];
+    }
+}

--- a/src/Provider/Doctrine/Persistence/Reader/Filter/SimpleFilter.php
+++ b/src/Provider/Doctrine/Persistence/Reader/Filter/SimpleFilter.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter;
+
+class SimpleFilter implements FilterInterface
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var array|string
+     */
+    protected $value;
+
+    public function __construct(string $name, $value)
+    {
+        $this->name = $name;
+        $this->value = $value;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return array|string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function getSQL(): array
+    {
+        if (\is_array($this->value) && 1 < \count($this->value)) {
+            $data = [
+                'sql' => sprintf('%s IN (:%s)', $this->name, $this->name),
+                'params' => [$this->name => $this->value],
+            ];
+        } else {
+            $data = [
+                'sql' => sprintf('%s = :%s', $this->name, $this->name),
+                'params' => [$this->name => (\is_array($this->value) ? $this->value[0] : $this->value)],
+            ];
+        }
+
+        return $data;
+    }
+}

--- a/src/Provider/Doctrine/Persistence/Reader/Query.php
+++ b/src/Provider/Doctrine/Persistence/Reader/Query.php
@@ -106,7 +106,8 @@ class Query
             $this->checkFilter($filter->getName());
             $this->filters[$filter->getName()][] = $filter;
         } else {
-            // TODO: deprecation notice
+            @trigger_error('Passing name and value is deprecated, you should pass a FilterInterface object instead.', E_USER_DEPRECATED);
+
             $this->checkFilter($filter);
             $this->filters[$filter][] = new SimpleFilter($filter, $value);
         }
@@ -120,13 +121,15 @@ class Query
      */
     public function addRangeFilter(string $name, $minValue = null, $maxValue = null): self
     {
-        // TODO: deprecation notice
+        @trigger_error('Deprecated method, you should call Query::addFilter(...) instead and pass it a RangeFilter object.', E_USER_DEPRECATED);
+
         return $this->addFilter(new RangeFilter($name, $minValue, $maxValue));
     }
 
     public function addDateRangeFilter(string $name, ?DateTime $minValue = null, ?DateTime $maxValue = null): self
     {
-        // TODO: deprecation notice
+        @trigger_error('Deprecated method, you should call Query::addFilter(...) instead and pass it a DateRangeFilter object.', E_USER_DEPRECATED);
+
         return $this->addFilter(new DateRangeFilter($name, $minValue, $maxValue));
     }
 

--- a/src/Provider/Doctrine/Persistence/Schema/SchemaManager.php
+++ b/src/Provider/Doctrine/Persistence/Schema/SchemaManager.php
@@ -29,7 +29,6 @@ class SchemaManager
 
     public function updateAuditSchema(?array $sqls = null, ?callable $callback = null): void
     {
-        // TODO: FIXME will create the same schema on all connections
         if (null === $sqls) {
             $sqls = $this->getUpdateAuditSchemaSql();
         }

--- a/tests/Provider/Doctrine/Persistence/Reader/QueryTest.php
+++ b/tests/Provider/Doctrine/Persistence/Reader/QueryTest.php
@@ -4,6 +4,9 @@ namespace DH\Auditor\Tests\Provider\Doctrine\Persistence\Reader;
 
 use DateTime;
 use DH\Auditor\Exception\InvalidArgumentException;
+use DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter\DateRangeFilter;
+use DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter\RangeFilter;
+use DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter\SimpleFilter;
 use DH\Auditor\Provider\Doctrine\Persistence\Reader\Query;
 use DH\Auditor\Tests\Provider\Doctrine\Traits\ConnectionTrait;
 use DH\Auditor\Tests\Traits\ReflectionTrait;
@@ -30,22 +33,53 @@ final class QueryTest extends TestCase
     /**
      * @depends testNoFiltersByDefault
      */
-    public function testAddFilter(): void
+    public function testAddSimpleFilter(): void
+    {
+        $query = new Query('author_audit', $this->createConnection());
+        $filter1 = new SimpleFilter(Query::TRANSACTION_HASH, '123abc');
+        $query->addFilter($filter1);
+
+        $filters = $query->getFilters();
+        self::assertCount(1, $filters[Query::TRANSACTION_HASH], 'Filter is added.');
+        self::assertSame([$filter1], $filters[Query::TRANSACTION_HASH], 'Filter is added.');
+
+        $filter2 = new SimpleFilter(Query::TRANSACTION_HASH, '456def');
+        $query->addFilter($filter2);
+
+        $filters = $query->getFilters();
+        self::assertCount(2, $filters[Query::TRANSACTION_HASH], 'Filter is added.');
+        self::assertSame([$filter1, $filter2], $filters[Query::TRANSACTION_HASH], 'Second filter is added.');
+
+        $filter3 = new SimpleFilter(Query::TRANSACTION_HASH, ['789ghi', '012jkl']);
+        $query->addFilter($filter3);
+
+        $filters = $query->getFilters();
+        self::assertCount(3, $filters[Query::TRANSACTION_HASH], 'Filter is added.');
+        self::assertSame([$filter1, $filter2, $filter3], $filters[Query::TRANSACTION_HASH], 'Second filter is added.');
+    }
+
+    /**
+     * @depends testAddSimpleFilter
+     */
+    public function testAddFilterDeprecation(): void
     {
         $query = new Query('author_audit', $this->createConnection());
         $query->addFilter(Query::TRANSACTION_HASH, '123abc');
 
         $filters = $query->getFilters();
-        self::assertSame(['123abc'], $filters[Query::TRANSACTION_HASH], 'Filter is added.');
+        self::assertCount(1, $filters[Query::TRANSACTION_HASH], 'Filter is added.');
+        self::assertSame('123abc', $filters[Query::TRANSACTION_HASH][0]->getValue(), 'Filter is added.');
 
         $query->addFilter(Query::TRANSACTION_HASH, '456def');
 
         $filters = $query->getFilters();
-        self::assertSame(['123abc', '456def'], $filters[Query::TRANSACTION_HASH], 'Second filter is added.');
+        self::assertCount(2, $filters[Query::TRANSACTION_HASH], 'Filter is added.');
+        self::assertSame('123abc', $filters[Query::TRANSACTION_HASH][0]->getValue(), 'First filter is ok.');
+        self::assertSame('456def', $filters[Query::TRANSACTION_HASH][1]->getValue(), 'Second filter is added.');
     }
 
     /**
-     * @depends testAddFilter
+     * @depends testAddSimpleFilter
      */
     public function testAddUnexpectedFilter(): void
     {
@@ -53,7 +87,7 @@ final class QueryTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
 
-        $query->addFilter('unknown_filter', '123abc');
+        $query->addFilter(new SimpleFilter('unknown_filter', '123abc'));
     }
 
     /**
@@ -63,24 +97,27 @@ final class QueryTest extends TestCase
     {
         // only min bound
         $query = new Query('author_audit', $this->createConnection());
-        $query->addRangeFilter(Query::OBJECT_ID, 1);
+        $filter = new RangeFilter(Query::OBJECT_ID, 1);
+        $query->addFilter($filter);
+
         $filters = $query->getFilters();
-        self::assertSame([[1, null]], $filters[Query::OBJECT_ID], 'Range filter with min bound only is added.');
+        self::assertSame([$filter], $filters[Query::OBJECT_ID], 'Range filter with min bound only is added.');
 
         // only max bound
         $query = new Query('author_audit', $this->createConnection());
-        $query->addRangeFilter(Query::OBJECT_ID, null, 1);
+        $filter = new RangeFilter(Query::OBJECT_ID, null, 1);
+        $query->addFilter($filter);
+
         $filters = $query->getFilters();
-        self::assertSame([[null, 1]], $filters[Query::OBJECT_ID], 'Range filter with max bound only is added.');
+        self::assertSame([$filter], $filters[Query::OBJECT_ID], 'Range filter with max bound only is added.');
 
         // min and max bound
         $query = new Query('author_audit', $this->createConnection());
-        $query->addRangeFilter(Query::OBJECT_ID, 5, 15);
-        $filters = $query->getFilters();
-        self::assertSame([[5, 15]], $filters[Query::OBJECT_ID], 'Range filter with both bound is added.');
+        $filter = new RangeFilter(Query::OBJECT_ID, 5, 15);
+        $query->addFilter($filter);
 
-        $this->expectException(InvalidArgumentException::class);
-        $query->addRangeFilter(Query::OBJECT_ID);
+        $filters = $query->getFilters();
+        self::assertSame([$filter], $filters[Query::OBJECT_ID], 'Range filter with both bound is added.');
     }
 
     /**
@@ -93,24 +130,27 @@ final class QueryTest extends TestCase
 
         // only min bound
         $query = new Query('author_audit', $this->createConnection());
-        $query->addDateRangeFilter(Query::CREATED_AT, $min);
+        $filter = new DateRangeFilter(Query::CREATED_AT, $min);
+        $query->addFilter($filter);
+
         $filters = $query->getFilters();
-        self::assertSame([[$min->format('Y-m-d H:i:s'), null]], $filters[Query::CREATED_AT], 'Date range filter with min bound only is added.');
+        self::assertSame([$filter], $filters[Query::CREATED_AT], 'Date range filter with min bound only is added.');
 
         // only max bound
         $query = new Query('author_audit', $this->createConnection());
-        $query->addDateRangeFilter(Query::CREATED_AT, null, $max);
+        $filter = new DateRangeFilter(Query::CREATED_AT, null, $max);
+        $query->addFilter($filter);
+
         $filters = $query->getFilters();
-        self::assertSame([[null, $max->format('Y-m-d H:i:s')]], $filters[Query::CREATED_AT], 'Date range filter with max bound only is added.');
+        self::assertSame([$filter], $filters[Query::CREATED_AT], 'Date range filter with max bound only is added.');
 
         // min and max bound
         $query = new Query('author_audit', $this->createConnection());
-        $query->addDateRangeFilter(Query::CREATED_AT, $min, $max);
-        $filters = $query->getFilters();
-        self::assertSame([[$min->format('Y-m-d H:i:s'), $max->format('Y-m-d H:i:s')]], $filters[Query::CREATED_AT], 'Date range filter with both bound is added.');
+        $filter = new DateRangeFilter(Query::CREATED_AT, $min, $max);
+        $query->addFilter($filter);
 
-        $this->expectException(InvalidArgumentException::class);
-        $query->addDateRangeFilter(Query::CREATED_AT);
+        $filters = $query->getFilters();
+        self::assertSame([$filter], $filters[Query::CREATED_AT], 'Date range filter with both bound is added.');
     }
 
     public function testNoOrderByByDefault(): void
@@ -210,7 +250,7 @@ final class QueryTest extends TestCase
     }
 
     /**
-     * @depends testAddFilter
+     * @depends testAddSimpleFilter
      * @depends testAddOrderBy
      */
     public function testBuildQueryBuilderDefault(): void
@@ -233,14 +273,13 @@ final class QueryTest extends TestCase
     {
         $query = new Query('author_audit', $this->createConnection());
         $reflectedMethod = $this->reflectMethod($query, 'buildQueryBuilder');
-        $queryBuilder = $reflectedMethod->invokeArgs($query, []);
 
         // test SQL query with 1 filter
         $expectedQuery = 'SELECT * FROM author_audit at WHERE transaction_hash = :transaction_hash';
         $expectedParameters = [
             'transaction_hash' => '123abc',
         ];
-        $query->addFilter(Query::TRANSACTION_HASH, '123abc');
+        $query->addFilter(new SimpleFilter(Query::TRANSACTION_HASH, '123abc'));
         $queryBuilder = $reflectedMethod->invokeArgs($query, []);
         self::assertSame($expectedQuery, $queryBuilder->getSQL(), 'SQL query is OK with 1 filter.');
         self::assertSame($expectedParameters, $queryBuilder->getParameters(), 'Parameters OK with 1 filter.');
@@ -250,10 +289,20 @@ final class QueryTest extends TestCase
         $expectedParameters = [
             'transaction_hash' => ['123abc', '456def'],
         ];
-        $query->addFilter(Query::TRANSACTION_HASH, '456def');
+        $query->addFilter(new SimpleFilter(Query::TRANSACTION_HASH, '456def'));
         $queryBuilder = $reflectedMethod->invokeArgs($query, []);
-        self::assertSame($expectedQuery, $queryBuilder->getSQL(), 'SQL query is OK with 1 filter.');
+        self::assertSame($expectedQuery, $queryBuilder->getSQL(), 'SQL query is OK with 2 filters.');
         self::assertSame($expectedParameters, $queryBuilder->getParameters(), 'Parameters OK with 2 filters.');
+
+        // test SQL query with 3 filters
+        $expectedQuery = 'SELECT * FROM author_audit at WHERE transaction_hash IN (:transaction_hash)';
+        $expectedParameters = [
+            'transaction_hash' => ['123abc', '456def', '789ghj', '012jkl'],
+        ];
+        $query->addFilter(new SimpleFilter(Query::TRANSACTION_HASH, ['789ghj', '012jkl']));
+        $queryBuilder = $reflectedMethod->invokeArgs($query, []);
+        self::assertSame($expectedQuery, $queryBuilder->getSQL(), 'SQL query is OK with 3 filters.');
+        self::assertSame($expectedParameters, $queryBuilder->getParameters(), 'Parameters OK with 3 filters.');
     }
 
     /**
@@ -263,7 +312,6 @@ final class QueryTest extends TestCase
     {
         $query = new Query('author_audit', $this->createConnection());
         $reflectedMethod = $this->reflectMethod($query, 'buildQueryBuilder');
-        $queryBuilder = $reflectedMethod->invokeArgs($query, []);
 
         // test SQL query with 1 ORDER BY
         $expectedQuery = 'SELECT * FROM author_audit at ORDER BY created_at DESC';
@@ -285,7 +333,6 @@ final class QueryTest extends TestCase
     {
         $query = new Query('author_audit', $this->createConnection());
         $reflectedMethod = $this->reflectMethod($query, 'buildQueryBuilder');
-        $queryBuilder = $reflectedMethod->invokeArgs($query, []);
 
         // test SQL query with LIMIT
         $expectedQuery = 'SELECT * FROM author_audit at LIMIT 10';
@@ -308,30 +355,27 @@ final class QueryTest extends TestCase
         // test SQL query with a range filter, min bound only
         $query = new Query('author_audit', $this->createConnection());
         $reflectedMethod = $this->reflectMethod($query, 'buildQueryBuilder');
-        $queryBuilder = $reflectedMethod->invokeArgs($query, []);
 
         $expectedQuery = 'SELECT * FROM author_audit at WHERE object_id >= :min_object_id';
-        $query->addRangeFilter(Query::OBJECT_ID, 5);
+        $query->addFilter(new RangeFilter(Query::OBJECT_ID, 5));
         $queryBuilder = $reflectedMethod->invokeArgs($query, []);
         self::assertSame($expectedQuery, $queryBuilder->getSQL(), 'SQL query is OK with a range filter with min bound only.');
 
         // test SQL query with a range filter, max bound only
         $query = new Query('author_audit', $this->createConnection());
         $reflectedMethod = $this->reflectMethod($query, 'buildQueryBuilder');
-        $queryBuilder = $reflectedMethod->invokeArgs($query, []);
 
         $expectedQuery = 'SELECT * FROM author_audit at WHERE object_id <= :max_object_id';
-        $query->addRangeFilter(Query::OBJECT_ID, null, 25);
+        $query->addFilter(new RangeFilter(Query::OBJECT_ID, null, 25));
         $queryBuilder = $reflectedMethod->invokeArgs($query, []);
         self::assertSame($expectedQuery, $queryBuilder->getSQL(), 'SQL query is OK with a range filter with max bound only.');
 
         // test SQL query with a range filter with both bounds
         $query = new Query('author_audit', $this->createConnection());
         $reflectedMethod = $this->reflectMethod($query, 'buildQueryBuilder');
-        $queryBuilder = $reflectedMethod->invokeArgs($query, []);
 
-        $expectedQuery = 'SELECT * FROM author_audit at WHERE (object_id >= :min_object_id) AND (object_id <= :max_object_id)';
-        $query->addRangeFilter(Query::OBJECT_ID, 5, 25);
+        $expectedQuery = 'SELECT * FROM author_audit at WHERE object_id >= :min_object_id AND object_id <= :max_object_id';
+        $query->addFilter(new RangeFilter(Query::OBJECT_ID, 5, 25));
         $queryBuilder = $reflectedMethod->invokeArgs($query, []);
         self::assertSame($expectedQuery, $queryBuilder->getSQL(), 'SQL query is OK with a range filter with max bound only.');
     }
@@ -347,30 +391,27 @@ final class QueryTest extends TestCase
         // test SQL query with a date range filter, min bound only
         $query = new Query('author_audit', $this->createConnection());
         $reflectedMethod = $this->reflectMethod($query, 'buildQueryBuilder');
-        $queryBuilder = $reflectedMethod->invokeArgs($query, []);
 
         $expectedQuery = 'SELECT * FROM author_audit at WHERE object_id >= :min_object_id';
-        $query->addRangeFilter(Query::OBJECT_ID, $min->format('Y-m-d H:i:s'));
+        $query->addFilter(new RangeFilter(Query::OBJECT_ID, $min->format('Y-m-d H:i:s')));
         $queryBuilder = $reflectedMethod->invokeArgs($query, []);
         self::assertSame($expectedQuery, $queryBuilder->getSQL(), 'SQL query is OK with a range filter with min bound only.');
 
         // test SQL query with a date range filter, max bound only
         $query = new Query('author_audit', $this->createConnection());
         $reflectedMethod = $this->reflectMethod($query, 'buildQueryBuilder');
-        $queryBuilder = $reflectedMethod->invokeArgs($query, []);
 
         $expectedQuery = 'SELECT * FROM author_audit at WHERE object_id <= :max_object_id';
-        $query->addRangeFilter(Query::OBJECT_ID, null, $max->format('Y-m-d H:i:s'));
+        $query->addFilter(new RangeFilter(Query::OBJECT_ID, null, $max->format('Y-m-d H:i:s')));
         $queryBuilder = $reflectedMethod->invokeArgs($query, []);
         self::assertSame($expectedQuery, $queryBuilder->getSQL(), 'SQL query is OK with a range filter with max bound only.');
 
         // test SQL query with a date range filter with both bounds
         $query = new Query('author_audit', $this->createConnection());
         $reflectedMethod = $this->reflectMethod($query, 'buildQueryBuilder');
-        $queryBuilder = $reflectedMethod->invokeArgs($query, []);
 
-        $expectedQuery = 'SELECT * FROM author_audit at WHERE (object_id >= :min_object_id) AND (object_id <= :max_object_id)';
-        $query->addRangeFilter(Query::OBJECT_ID, $min->format('Y-m-d H:i:s'), $max->format('Y-m-d H:i:s'));
+        $expectedQuery = 'SELECT * FROM author_audit at WHERE object_id >= :min_object_id AND object_id <= :max_object_id';
+        $query->addFilter(new RangeFilter(Query::OBJECT_ID, $min->format('Y-m-d H:i:s'), $max->format('Y-m-d H:i:s')));
         $queryBuilder = $reflectedMethod->invokeArgs($query, []);
         self::assertSame($expectedQuery, $queryBuilder->getSQL(), 'SQL query is OK with a range filter with max bound only.');
     }

--- a/tests/Provider/Doctrine/Persistence/Reader/ReaderTest.php
+++ b/tests/Provider/Doctrine/Persistence/Reader/ReaderTest.php
@@ -6,6 +6,8 @@ use DateTime;
 use DH\Auditor\Exception\InvalidArgumentException;
 use DH\Auditor\Model\Entry;
 use DH\Auditor\Model\Transaction;
+use DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter\DateRangeFilter;
+use DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter\SimpleFilter;
 use DH\Auditor\Provider\Doctrine\Persistence\Reader\Query;
 use DH\Auditor\Provider\Doctrine\Service\StorageService;
 use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Standard\Blog\Author;
@@ -190,8 +192,8 @@ final class ReaderTest extends TestCase
         self::assertCount(5, $audits);
 
         $query = $reader->createQuery(Author::class);
-        $query->addFilter('object_id', 1);
-        $query->addFilter('object_id', 2);
+        $query->addFilter(new SimpleFilter('object_id', 1));
+        $query->addFilter(new SimpleFilter('object_id', 2));
         $audits = $query->execute();
         self::assertCount(3, $audits);
     }
@@ -206,7 +208,7 @@ final class ReaderTest extends TestCase
         /** @var Entry[] $audits */
         $audits = $reader
             ->createQuery(Author::class)
-            ->addDateRangeFilter(Query::CREATED_AT, new DateTime('-1 day'))
+            ->addFilter(new DateRangeFilter(Query::CREATED_AT, new DateTime('-1 day')))
             ->execute()
         ;
 
@@ -221,7 +223,7 @@ final class ReaderTest extends TestCase
         /** @var Entry[] $audits */
         $audits = $reader
             ->createQuery(Author::class)
-            ->addDateRangeFilter(Query::CREATED_AT, new DateTime('-5 days'), new DateTime('-4 days'))
+            ->addFilter(new DateRangeFilter(Query::CREATED_AT, new DateTime('-5 days'), new DateTime('-4 days')))
             ->execute()
         ;
         self::assertCount(0, $audits, 'result count is ok.');
@@ -229,7 +231,7 @@ final class ReaderTest extends TestCase
         /** @var Entry[] $audits */
         $audits = $reader
             ->createQuery(Author::class, ['page_size' => 2])
-            ->addDateRangeFilter(Query::CREATED_AT, new DateTime('-1 day'))
+            ->addFilter(new DateRangeFilter(Query::CREATED_AT, new DateTime('-1 day')))
             ->execute()
         ;
         self::assertCount(2, $audits, 'result count is ok.');
@@ -237,7 +239,7 @@ final class ReaderTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $reader
             ->createQuery(Post::class)
-            ->addDateRangeFilter(Query::CREATED_AT, new DateTime('now'), new DateTime('-1 day'))
+            ->addFilter(new DateRangeFilter(Query::CREATED_AT, new DateTime('now'), new DateTime('-1 day')))
             ->execute()
         ;
     }


### PR DESCRIPTION
New and more robust filtering system.

```php
Query::addFilter(string $name, $value)
Query::addRangeFilter(string $name, $minValue, $maxValue)
Query::addDateRangeFilter(string $name, $minValue, $maxValue)
``` 
are now deprecated in favor of
```php
Query::addFilter(FilterInterface $filter)
``` 

There are several kinds of filters:
- `SimpleFilter` lets you filter by a specific value or set of values
- `RangeFilter` lets you filter by a range of values
- `DateRangeFilter` lets you filter by a range of dates

Should fix #29
