### PR TITLE
Set database ID on LifecycleEvent payload in DoctrineProvider

### DIFF
--- a/src/Provider/Doctrine/DoctrineProvider.php
+++ b/src/Provider/Doctrine/DoctrineProvider.php
@@ -125,6 +125,11 @@ class DoctrineProvider extends AbstractProvider
         }
 
         $statement->execute();
+
+        // let's get the last inserted ID from the database so other providers can use that info
+        $payload = $event->getPayload();
+        $payload['id'] = (int)$storageService->getEntityManager()->getConnection()->lastInsertId();
+        $event->setPayload($payload);
     }
 
     /**


### PR DESCRIPTION
The Provider that inserts an audit log into a database should add an ID information to payload so other providers can use that information.

Let's say we have the provider that fills ElasticSearch, we need to have the ID of database entry so afterward we can easily find that entry no matter if we are looking in a database or ElasticSearch.

---------------

I have the problem I described, so this is my try to improve that part. Sorry for not adding tests, could not find any that checks what array key, values are inside payload of `LifecycleEvent`. Can you please give me some directions where and how to add tests? Couldn't find test that tests `persist` method of `DoctrineProvider`.