### PR TITLE
feat: Add support to php 8 attributes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,85 @@ jobs:
 
       - name: Run tests
         run: vendor/bin/phpunit -c phpunit.${{ matrix.db }}.xml
+
+  tests-symfony-next:
+    name: Tests PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, ${{ matrix.db }}
+    runs-on: ubuntu-18.04
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: auditor
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    strategy:
+      matrix:
+        php:
+          - '8.0'
+        symfony:
+          - '5.*'
+        db:
+          - 'sqlite'
+          - 'mysql'
+          - 'pgsql'
+      fail-fast: false
+
+    steps:
+      - name: Shutdown Ubuntu MySQL (SUDO)
+        run: sudo service mysql stop # Shutdown the Default MySQL, "sudo" is necessary, please not remove it
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: composer:v2, flex, pcov
+          coverage: pcov
+
+      - name: Configure Symfony
+        run: |
+          composer global require --no-progress --no-scripts --no-plugins symfony/flex
+          composer config extra.symfony.require "${{ matrix.symfony }}"
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ matrix.php }}-composer-
+
+      - name: Update project dependencies (5.*)
+        if: matrix.symfony == '5.*'
+        run: composer update --no-progress --ansi --prefer-stable
+
+      - name: Validate composer
+        run: composer validate --strict --no-check-lock
+
+      - name: Run tests
+        run: vendor/bin/phpunit -c phpunit.${{ matrix.db }}.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .idea/
 .php_cs.cache
+.php-cs-fixer.cache
 .phpunit.result.cache
 /vendor/
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ php:
     - 7.2
     - 7.3
     - 7.4
+    - 8.0
 
 env:
     - DB=sqlite
@@ -35,9 +36,11 @@ script:
     - if [ $(phpenv version-name) = "7.2" ]; then ./vendor/bin/phpunit -c phpunit.$DB.xml --disable-coverage; fi
     - if [ $(phpenv version-name) = "7.3" ]; then ./vendor/bin/phpunit -c phpunit.$DB.xml --disable-coverage; fi
     - if [ $(phpenv version-name) = "7.4" ]; then php -d pcov.enabled=1 ./vendor/bin/phpunit -c phpunit.$DB.xml --coverage-clover clover.xml; fi
+    - if [ $(phpenv version-name) = "8.0" ]; then php -d pcov.enabled=1 ./vendor/bin/phpunit -c phpunit.$DB.xml --coverage-clover clover.xml; fi
 
 after_script:
     - if [ $(phpenv version-name) = "7.4" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then bash <(curl -s https://codecov.io/bash); fi
+    - if [ $(phpenv version-name) = "8.0" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then bash <(curl -s https://codecov.io/bash); fi
 
 jobs:
     fast_finish: true

--- a/src/Provider/Doctrine/Auditing/Annotation/Auditable.php
+++ b/src/Provider/Doctrine/Auditing/Annotation/Auditable.php
@@ -2,19 +2,28 @@
 
 namespace DH\Auditor\Provider\Doctrine\Auditing\Annotation;
 
+use Attribute;
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * @Annotation
+ * @NamedArgumentConstructor()
  * @Target("CLASS")
  * @Attributes({
  *     @Attribute("enabled", required=false, type="bool"),
  * })
  */
-final class Auditable extends Annotation
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Auditable
 {
     /**
      * @var bool
      */
     public $enabled = true;
+
+    public function __construct(bool $enabled = true)
+    {
+        $this->enabled = $enabled;
+    }
 }

--- a/src/Provider/Doctrine/Auditing/Annotation/Ignore.php
+++ b/src/Provider/Doctrine/Auditing/Annotation/Ignore.php
@@ -2,6 +2,7 @@
 
 namespace DH\Auditor\Provider\Doctrine\Auditing\Annotation;
 
+use Attribute;
 use Doctrine\Common\Annotations\Annotation;
 
 /**
@@ -9,6 +10,7 @@ use Doctrine\Common\Annotations\Annotation;
  *
  * @Target("PROPERTY")
  */
-final class Ignore extends Annotation
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Ignore
 {
 }

--- a/src/Provider/Doctrine/Auditing/Annotation/Security.php
+++ b/src/Provider/Doctrine/Auditing/Annotation/Security.php
@@ -2,17 +2,21 @@
 
 namespace DH\Auditor\Provider\Doctrine\Auditing\Annotation;
 
+use Attribute;
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\Common\Annotations\Annotation\Required;
 
 /**
  * @Annotation
+ * @NamedArgumentConstructor()
  * @Target("CLASS")
  * @Attributes({
  *     @Attribute("view", required=true, type="array<string>"),
  * })
  */
-final class Security extends Annotation
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Security
 {
     public const VIEW_SCOPE = 'view';
 
@@ -21,4 +25,9 @@ final class Security extends Annotation
      * @Required
      */
     public $view;
+
+    public function __construct(array $view)
+    {
+        $this->view = $view;
+    }
 }

--- a/tests/Provider/Doctrine/Fixtures/Entity/Annotation/AuditableButUnauditedEntity.php
+++ b/tests/Provider/Doctrine/Fixtures/Entity/Annotation/AuditableButUnauditedEntity.php
@@ -12,6 +12,8 @@ use Doctrine\ORM\Mapping as ORM;
  * @Audit\Auditable(enabled=false)
  * @Audit\Security(view={"ROLE1", "ROLE2"})
  */
+#[ORM\Entity, ORM\Table(name: 'auditable_but_unaudited_entity')]
+#[Audit\Auditable(enabled: false), Audit\Security(view: ['ROLE1', 'ROLE2'])]
 class AuditableButUnauditedEntity
 {
     /**
@@ -24,11 +26,16 @@ class AuditableButUnauditedEntity
      *
      * @Audit\Ignore
      */
+    #[Audit\Ignore]
     public $ignoredField;
+
     /**
+     * @var int
+     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id, ORM\GeneratedValue(strategy: 'IDENTITY'), ORM\Column(type: 'integer')]
     private $id;
 }

--- a/tests/Provider/Doctrine/Fixtures/Entity/Annotation/AuditedEntity.php
+++ b/tests/Provider/Doctrine/Fixtures/Entity/Annotation/AuditedEntity.php
@@ -11,6 +11,8 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @Audit\Auditable
  */
+#[ORM\Entity, ORM\Table(name: 'audited_entity')]
+#[Audit\Auditable]
 class AuditedEntity
 {
     /**
@@ -23,11 +25,16 @@ class AuditedEntity
      *
      * @Audit\Ignore
      */
+    #[Audit\Ignore]
     public $ignoredField;
+
     /**
+     * @var int
+     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id, ORM\GeneratedValue(strategy: 'IDENTITY'), ORM\Column(type: 'integer')]
     private $id;
 }

--- a/tests/Provider/Doctrine/Fixtures/Entity/Inheritance/Joined/Animal.php
+++ b/tests/Provider/Doctrine/Fixtures/Entity/Inheritance/Joined/Animal.php
@@ -11,17 +11,27 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\DiscriminatorColumn(name="type", type="string")
  * @ORM\DiscriminatorMap({"cat": "Cat", "dog": "Dog"})
  */
+#[ORM\Entity, ORM\Table(name: 'animal'), ORM\InheritanceType('JOINED')]
+#[ORM\DiscriminatorColumn(name: 'type', type: 'string')]
+#[ORM\DiscriminatorMap(['cat' => 'Cat', 'dog' => 'Dog'])]
 abstract class Animal
 {
     /**
+     * @var string
+     *
      * @ORM\Column(type="string", length=50)
      */
+    #[ORM\Column(type: 'string', length: 50)]
     protected $label;
+
     /**
+     * @var int
+     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id, ORM\GeneratedValue(strategy: 'IDENTITY'), ORM\Column(type: 'integer')]
     private $id;
 
     final public function getId()

--- a/tests/Provider/Doctrine/Fixtures/Entity/Inheritance/Joined/Cat.php
+++ b/tests/Provider/Doctrine/Fixtures/Entity/Inheritance/Joined/Cat.php
@@ -2,13 +2,13 @@
 
 namespace DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\Joined;
 
-use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\Joined\Animal;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
  * @ORM\Table(name="cat")
  */
+#[ORM\Entity, ORM\Table(name: 'cat')]
 class Cat extends Animal
 {
 }

--- a/tests/Provider/Doctrine/Fixtures/Entity/Inheritance/Joined/Dog.php
+++ b/tests/Provider/Doctrine/Fixtures/Entity/Inheritance/Joined/Dog.php
@@ -2,13 +2,13 @@
 
 namespace DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\Joined;
 
-use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\Joined\Animal;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
  * @ORM\Table(name="dog")
  */
+#[ORM\Entity, ORM\Table(name: 'dog')]
 class Dog extends Animal
 {
 }

--- a/tests/Provider/Doctrine/Fixtures/Entity/Inheritance/SingleTable/Bike.php
+++ b/tests/Provider/Doctrine/Fixtures/Entity/Inheritance/SingleTable/Bike.php
@@ -2,12 +2,12 @@
 
 namespace DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\SingleTable;
 
-use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\SingleTable\Vehicle;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Bike extends Vehicle
 {
 }

--- a/tests/Provider/Doctrine/Fixtures/Entity/Inheritance/SingleTable/Car.php
+++ b/tests/Provider/Doctrine/Fixtures/Entity/Inheritance/SingleTable/Car.php
@@ -2,12 +2,12 @@
 
 namespace DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\SingleTable;
 
-use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\SingleTable\Vehicle;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
  */
+#[ORM\Entity]
 class Car extends Vehicle
 {
 }

--- a/tests/Provider/Doctrine/Fixtures/Entity/Inheritance/SingleTable/Vehicle.php
+++ b/tests/Provider/Doctrine/Fixtures/Entity/Inheritance/SingleTable/Vehicle.php
@@ -11,22 +11,35 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\DiscriminatorColumn(name="type", type="string")
  * @ORM\DiscriminatorMap({"vehicle": "Vehicle", "car": "Car", "bike": "Bike"})
  */
+#[ORM\Entity, ORM\Table(name: 'vehicle'), ORM\InheritanceType('SINGLE_TABLE')]
+#[ORM\DiscriminatorColumn(name: 'type', type: 'string')]
+#[ORM\DiscriminatorMap(['vehicle' => 'Vehicle', 'car' => 'Car', 'bike' => 'Bike'])]
 class Vehicle
 {
     /**
+     * @var string
+     *
      * @ORM\Column(type="string", length=50)
      */
+    #[ORM\Column(type: 'string', length: 50)]
     protected $label;
+
     /**
+     * @var int
+     *
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id, ORM\GeneratedValue(strategy: 'IDENTITY'), ORM\Column(type: 'integer')]
     private $id;
 
     /**
+     * @var int
+     *
      * @ORM\Column(type="integer")
      */
+    #[ORM\Column(type: 'integer')]
     private $wheels;
 
     public function getWheels(): int

--- a/tests/Provider/Doctrine/Fixtures/Entity/Standard/Blog/Author.php
+++ b/tests/Provider/Doctrine/Fixtures/Entity/Standard/Blog/Author.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  * @ORM\Table(name="author")
  */
+#[ORM\Entity, ORM\Table(name: 'author')]
 class Author
 {
     /**
@@ -17,22 +18,27 @@ class Author
      * @ORM\Column(type="integer", options={"unsigned": true})
      * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Id, ORM\GeneratedValue(strategy: 'IDENTITY'), ORM\Column(type: 'integer', options: ['unsigned' => true])]
     protected $id;
 
     /**
      * @ORM\Column(type="string", length=255)
      */
+    #[ORM\Column(type: 'string', length: 255)]
     protected $fullname;
 
     /**
      * @ORM\Column(type="string", length=255)
      */
+    #[ORM\Column(type: 'string', length: 255)]
     protected $email;
 
     /**
      * @ORM\OneToMany(targetEntity="Post", mappedBy="author", cascade={"persist", "remove"})
      * @ORM\JoinColumn(name="id", referencedColumnName="author_id", nullable=false)
      */
+    #[ORM\OneToMany(targetEntity: 'Post', mappedBy: 'author', cascade: ['persist', 'remove'])]
+    #[ORM\JoinColumn(name: 'id', referencedColumnName: 'author_id', nullable: false)]
     protected $posts;
 
     public function __construct()

--- a/tests/Provider/Doctrine/Fixtures/Entity/Standard/Blog/Comment.php
+++ b/tests/Provider/Doctrine/Fixtures/Entity/Standard/Blog/Comment.php
@@ -3,7 +3,6 @@
 namespace DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Standard\Blog;
 
 use DateTime;
-use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Standard\Blog\Post;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
@@ -11,6 +10,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
  * @ORM\Entity
  * @ORM\Table(name="`comment`", indexes={@ORM\Index(name="fk_post_id", columns={"post_id"})})
  */
+#[ORM\Entity, ORM\Table(name: '`comment`'), ORM\Index(name: 'fk_post_id', columns: ['post_id'])]
 class Comment
 {
     /**
@@ -18,11 +18,13 @@ class Comment
      * @ORM\Column(type="integer", options={"unsigned": true})
      * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Id, ORM\GeneratedValue(strategy: 'IDENTITY'), ORM\Column(type: 'integer', options: ['unsigned' => true])]
     protected $id;
 
     /**
      * @ORM\Column(type="text")
      */
+    #[ORM\Column(type: 'text')]
     protected $body;
 
     /**
@@ -30,23 +32,28 @@ class Comment
      *
      * @ORM\Column(type="string", length=255)
      */
+    #[ORM\Column(type: 'string', length: 255)]
     protected $author;
 
     /**
      * @Gedmo\Timestampable(on="create")
      * @ORM\Column(type="datetime")
      */
+    #[ORM\Column(type: 'datetime')]
     protected $created_at;
 
     /**
      * @ORM\Column(type="integer", options={"unsigned": true})
      */
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
     protected $post_id;
 
     /**
      * @ORM\ManyToOne(targetEntity="Post", inversedBy="comments", cascade={"persist", "remove"})
      * @ORM\JoinColumn(name="post_id", referencedColumnName="id", nullable=false)
      */
+    #[ORM\ManyToOne(targetEntity: 'Post', inversedBy: 'comments', cascade: ['persist', 'remove'])]
+    #[ORM\JoinColumn(name: 'post_id', referencedColumnName: 'id', nullable: false)]
     protected $post;
 
     public function __construct()

--- a/tests/Provider/Doctrine/Fixtures/Entity/Standard/Blog/Post.php
+++ b/tests/Provider/Doctrine/Fixtures/Entity/Standard/Blog/Post.php
@@ -3,9 +3,6 @@
 namespace DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Standard\Blog;
 
 use DateTime;
-use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Standard\Blog\Author;
-use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Standard\Blog\Comment;
-use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Standard\Blog\Tag;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -16,6 +13,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
  * @ORM\Table(name="post", indexes={@ORM\Index(name="fk_author_id", columns={"author_id"})})
  * @Gedmo\SoftDeleteable(fieldName="deleted_at", timeAware=false)
  */
+#[ORM\Entity, ORM\Table(name: 'post'), ORM\Index(name: 'fk_author_id', columns: ['author_id'])]
 class Post
 {
     /**
@@ -23,44 +21,54 @@ class Post
      * @ORM\Column(type="integer", options={"unsigned": true})
      * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Id, ORM\GeneratedValue(strategy: 'IDENTITY'), ORM\Column(type: 'integer', options: ['unsigned' => true])]
     protected $id;
 
     /**
      * @ORM\Column(type="string", length=255)
      */
+    #[ORM\Column(type: 'string', length: 255)]
     protected $title;
 
     /**
      * @ORM\Column(type="text")
      */
+    #[ORM\Column(type: 'text')]
     protected $body;
 
     /**
      * @Gedmo\Timestampable(on="create")
      * @ORM\Column(type="datetime")
      */
+    #[ORM\Column(type: 'datetime')]
     protected $created_at;
 
     /**
      * @ORM\Column(type="datetime", nullable=true, options={"default": NULL})
      */
+    #[ORM\Column(type: 'datetime', nullable: true, options: ['default' => null])]
     protected $deleted_at;
 
     /**
      * @ORM\Column(type="integer", options={"unsigned": true}, nullable=true)
      */
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true], nullable: true)]
     protected $author_id;
 
     /**
      * @ORM\OneToMany(targetEntity="Comment", mappedBy="post", cascade={"persist", "remove"})
      * @ORM\JoinColumn(name="id", referencedColumnName="post_id", nullable=true)
      */
+    #[ORM\OneToMany(targetEntity: 'Comment', mappedBy: 'post', cascade: ['persist', 'remove'])]
+    #[ORM\JoinColumn(name: 'id', referencedColumnName: 'post_id', nullable: true)]
     protected $comments;
 
     /**
      * @ORM\ManyToOne(targetEntity="Author", inversedBy="posts", cascade={"persist", "remove"})
      * @ORM\JoinColumn(name="author_id", referencedColumnName="id", nullable=true)
      */
+    #[ORM\ManyToOne(targetEntity: 'Author', inversedBy: 'posts', cascade: ['persist', 'remove'])]
+    #[ORM\JoinColumn(name: 'author_id', referencedColumnName: 'id', nullable: true)]
     protected $author;
 
     /**
@@ -70,6 +78,10 @@ class Post
      *     inverseJoinColumns={@ORM\JoinColumn(name="tag_id", referencedColumnName="id", nullable=false)}
      * )
      */
+    #[ORM\ManyToMany(targetEntity: 'Tag', inversedBy: 'posts', cascade: ['persist', 'remove'])]
+    #[ORM\JoinTable(name: 'post__tag')]
+    #[ORM\JoinColumn(name: 'post_id', referencedColumnName: 'id', nullable: false)]
+    #[ORM\InverseJoinColumn(name: 'tag_id', referencedColumnName: 'id', nullable: false)]
     protected $tags;
 
     public function __construct()

--- a/tests/Provider/Doctrine/Fixtures/Entity/Standard/Blog/Tag.php
+++ b/tests/Provider/Doctrine/Fixtures/Entity/Standard/Blog/Tag.php
@@ -2,7 +2,6 @@
 
 namespace DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Standard\Blog;
 
-use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Standard\Blog\Post;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -11,6 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  * @ORM\Table(name="tag")
  */
+#[ORM\Entity, ORM\Table(name: 'tag')]
 class Tag
 {
     /**
@@ -18,16 +18,19 @@ class Tag
      * @ORM\Column(type="integer", options={"unsigned": true})
      * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Id, ORM\GeneratedValue(strategy: 'IDENTITY'), ORM\Column(type: 'integer', options: ['unsigned' => true])]
     protected $id;
 
     /**
      * @ORM\Column(type="string", length=255)
      */
+    #[ORM\Column(type: 'string', length: 255)]
     protected $title;
 
     /**
      * @ORM\ManyToMany(targetEntity="Post", mappedBy="tags", cascade={"persist", "remove"})
      */
+    #[ORM\ManyToMany(targetEntity: 'Post', mappedBy: 'tags', cascade: ['persist', 'remove'])]
     protected $posts;
 
     public function __construct()

--- a/tests/Provider/Doctrine/Fixtures/Entity/Standard/DummyEntity.php
+++ b/tests/Provider/Doctrine/Fixtures/Entity/Standard/DummyEntity.php
@@ -8,47 +8,57 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  * @ORM\Table(name="dummy_entity")
  */
+#[ORM\Entity, ORM\Table(name: 'dummy_entity')]
 class DummyEntity
 {
     /**
      * @ORM\Column(type="string", length=50)
      */
+    #[ORM\Column(type: 'string', length: 50)]
     protected $label;
 
     /**
      * @ORM\Column(type="integer", nullable=true)
      */
+    #[ORM\Column(type: 'integer', nullable: true)]
     protected $int_value;
 
     /**
      * @ORM\Column(type="decimal", precision=8, scale=2, nullable=true)
      */
+    #[ORM\Column(type: 'decimal', precision: 8, scale: 2, nullable: true)]
     protected $decimal_value;
 
     /**
      * @ORM\Column(type="boolean", nullable=true, options={"default": "0"})
      */
+    #[ORM\Column(type: 'boolean', nullable: true, options: ['default' => '0'])]
     protected $bool_value;
 
     /**
      * @ORM\Column(type="array")
      */
+    #[ORM\Column(type: 'array')]
     protected $php_array;
 
     /**
      * @ORM\Column(type="json_array", nullable=true)
      */
+    #[ORM\Column(type: 'json_array', nullable: true)]
     protected $json_array;
 
     /**
      * @ORM\Column(type="simple_array", nullable=true)
      */
+    #[ORM\Column(type: 'simple_array', nullable: true)]
     protected $simple_array;
+
     /**
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id, ORM\GeneratedValue(strategy: 'IDENTITY'), ORM\Column(type: 'integer')]
     private $id;
 
     public function getId()

--- a/tests/Provider/Doctrine/Fixtures/Issue18/DataObject.php
+++ b/tests/Provider/Doctrine/Fixtures/Issue18/DataObject.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  * @ORM\Table(name="data_object")
  */
+#[ORM\Entity, ORM\Table(name: 'data_object')]
 class DataObject
 {
     /**
@@ -15,11 +16,13 @@ class DataObject
      * @ORM\Column(type="integer", options={"unsigned": true})
      * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Id, ORM\GeneratedValue(strategy: 'IDENTITY'), ORM\Column(type: 'integer', options: ['unsigned' => true])]
     protected $id;
 
     /**
      * @ORM\Column(type="binary")
      */
+    #[ORM\Column(type: 'binary')]
     protected $data;
 
     /**

--- a/tests/Provider/Doctrine/Fixtures/Issue33/Offer.php
+++ b/tests/Provider/Doctrine/Fixtures/Issue33/Offer.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  * @ORM\Table(name="offer")
  */
+#[ORM\Entity, ORM\Table(name: 'offer')]
 class Offer
 {
     /**
@@ -17,11 +18,13 @@ class Offer
      * @ORM\Column(type="integer", options={"unsigned": true})
      * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Id, ORM\GeneratedValue(strategy: 'IDENTITY'), ORM\Column(type: 'integer', options: ['unsigned' => true])]
     private $id;
 
     /**
      * @ORM\Column(type="string", length=255)
      */
+    #[ORM\Column(type: 'string', length: 255)]
     private $name;
 
     public function __construct(string $name)

--- a/tests/Provider/Doctrine/Fixtures/Issue33/Shop.php
+++ b/tests/Provider/Doctrine/Fixtures/Issue33/Shop.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  * @ORM\Table(name="shop")
  */
+#[ORM\Entity, ORM\Table(name: 'shop')]
 class Shop
 {
     /**
@@ -17,11 +18,13 @@ class Shop
      * @ORM\Column(type="integer", options={"unsigned": true})
      * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Id, ORM\GeneratedValue(strategy: 'IDENTITY'), ORM\Column(type: 'integer', options: ['unsigned' => true])]
     private $id;
 
     /**
      * @ORM\Column(type="string", length=255)
      */
+    #[ORM\Column(type: 'string', length: 255)]
     private $name;
 
     public function __construct(string $name)

--- a/tests/Provider/Doctrine/Fixtures/Issue33/ShopOfferPrice.php
+++ b/tests/Provider/Doctrine/Fixtures/Issue33/ShopOfferPrice.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  * @ORM\Table(name="shop_offer_price")
  */
+#[ORM\Entity, ORM\Table(name: 'shop_offer_price')]
 class ShopOfferPrice
 {
     /**
@@ -17,6 +18,8 @@ class ShopOfferPrice
      * @ORM\ManyToOne(targetEntity="Shop", cascade={"persist", "remove"})
      * @ORM\JoinColumn(name="shop_id", referencedColumnName="id", nullable=true)
      */
+    #[ORM\Id, ORM\ManyToOne(targetEntity: 'Shop', cascade: ['persist', 'remove'])]
+    #[ORM\JoinColumn(name: 'shop_id', referencedColumnName: 'id', nullable: true)]
     private $shop;
 
     /**
@@ -24,6 +27,8 @@ class ShopOfferPrice
      * @ORM\ManyToOne(targetEntity="Offer", cascade={"persist", "remove"})
      * @ORM\JoinColumn(name="offer_id", referencedColumnName="id", nullable=true)
      */
+    #[ORM\Id, ORM\ManyToOne(targetEntity: 'Offer', cascade: ['persist', 'remove'])]
+    #[ORM\JoinColumn(name: 'offer_id', referencedColumnName: 'id', nullable: true)]
     private $offer;
 
     /**

--- a/tests/Provider/Doctrine/Fixtures/Issue37/Locale.php
+++ b/tests/Provider/Doctrine/Fixtures/Issue37/Locale.php
@@ -8,17 +8,20 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  * @ORM\Table(name="locale")
  */
+#[ORM\Entity, ORM\Table(name: 'locale')]
 class Locale
 {
     /**
      * @ORM\Id
      * @ORM\Column(type="string", length=5)
      */
+    #[ORM\Id, ORM\Column(type: 'string', length: 5)]
     protected $id;
 
     /**
      * @ORM\Column(type="string", length=255)
      */
+    #[ORM\Column(type: 'string', length: 255)]
     protected $name;
 
     public function __sleep()

--- a/tests/Provider/Doctrine/Fixtures/Issue37/User.php
+++ b/tests/Provider/Doctrine/Fixtures/Issue37/User.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  * @ORM\Table(name="users")
  */
+#[ORM\Entity, ORM\Table(name: 'users')]
 class User
 {
     /**
@@ -15,22 +16,27 @@ class User
      * @ORM\Column(type="integer", options={"unsigned": true})
      * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Id, ORM\GeneratedValue(strategy: 'IDENTITY'), ORM\Column(type: 'integer', options: ['unsigned' => true])]
     protected $id;
 
     /**
      * @ORM\Column(type="string", length=255)
      */
+    #[ORM\Column(type: 'string', length: 255)]
     protected $username;
 
     /**
      * @ORM\Column(type="string", nullable=true, length=5)
      */
+    #[ORM\Column(type: 'string', nullable: true, length: 5)]
     protected $locale_id;
 
     /**
      * @ORM\ManyToOne(targetEntity="Locale", cascade={"persist", "remove"})
      * @ORM\JoinColumn(name="locale_id", referencedColumnName="id", nullable=true)
      */
+    #[ORM\ManyToOne(targetEntity: 'Locale', cascade: ['persist', 'remove'])]
+    #[ORM\JoinColumn(name: 'locale_id', referencedColumnName: 'id', nullable: true)]
     protected $locale;
 
     /**

--- a/tests/Provider/Doctrine/Fixtures/Issue40/CoreCase.php
+++ b/tests/Provider/Doctrine/Fixtures/Issue40/CoreCase.php
@@ -9,21 +9,26 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\HasLifecycleCallbacks
  * @ORM\Table(name="case_core")
  */
+#[ORM\Entity, ORM\HasLifecycleCallbacks, ORM\Table(name: 'case_core')]
 class CoreCase
 {
     /**
      * @ORM\Column(type="string", name="type", length=50)
      */
+    #[ORM\Column(type: 'string', name: 'type', length: 50)]
     public $type;
 
     /**
      * @ORM\Column(type="string", name="status", length=50)
      */
+    #[ORM\Column(type: 'string', name: 'status', length: 50)]
     public $status;
+
     /**
      * @ORM\Column(type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Id, ORM\GeneratedValue(strategy: 'IDENTITY'), ORM\Column(type: 'integer')]
     private $id;
 }

--- a/tests/Provider/Doctrine/Fixtures/Issue40/DieselCase.php
+++ b/tests/Provider/Doctrine/Fixtures/Issue40/DieselCase.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\HasLifecycleCallbacks
  * @ORM\Table(name="case_diesel")
  */
+#[ORM\Entity, ORM\HasLifecycleCallbacks, ORM\Table(name: 'case_diesel')]
 class DieselCase
 {
     /**
@@ -16,11 +17,14 @@ class DieselCase
      * @ORM\ManyToOne(targetEntity="CoreCase", cascade={"persist"})
      * @ORM\JoinColumn(name="core_case", referencedColumnName="id")
      */
+    #[ORM\Id, ORM\ManyToOne(targetEntity: 'CoreCase', cascade: ['persist'])]
+    #[ORM\JoinColumn(name: 'core_case', referencedColumnName: 'id')]
     public $coreCase;
 
     /**
      * @ORM\Column(type="string", length=50)
      */
+    #[ORM\Column(type: 'string', length: 50)]
     protected $name;
 
     /**


### PR DESCRIPTION
Add support to php 8 attributes, keeping compatibility with annotations.

```php
use DH\Auditor\Provider\Doctrine\Auditing\Annotation as Audit;

#[
    Audit\Auditable,
    Audit\Security(
        view: [
            'ROLE_ADMIN',
        ],
    ),
]
class DummyPhp8
{
    #[Audit\Ignore]
    public string $hello = 'hi';
}
```