### PR TITLE
on rollback remove flusher callback from logger

### DIFF
--- a/src/Provider/Doctrine/Auditing/Logger/Logger.php
+++ b/src/Provider/Doctrine/Auditing/Logger/Logger.php
@@ -25,6 +25,10 @@ class Logger implements SQLLogger
         if ('"COMMIT"' === $sql) {
             \call_user_func($this->flusher);
         }
+        // on rollback remove flusher callback
+        if ('"ROLLBACK"' === $sql) {
+            $this->flusher = static function(){};
+        }
     }
 
     /**


### PR DESCRIPTION
If an transaction failed and the entity manger is closed, resetting the entity manager and make a transaction in with the new one, the logger is still active and will create phantom inserts in audit table for the old not commited transaction.