### PR TITLE
Audit relationship refs

### DIFF
--- a/src/Model/Entry.php
+++ b/src/Model/Entry.php
@@ -155,9 +155,14 @@ class Entry
      *
      * @return array
      */
-    public function getDiffs(): ?array
+    public function getDiffs(bool $includeMedadata = false): ?array
     {
-        return $this->sort(json_decode($this->diffs, true));
+        $diffs = $this->sort(json_decode($this->diffs, true));
+        if (!$includeMedadata) {
+            unset($diffs['@source']);
+        }
+
+        return $diffs;
     }
 
     public static function fromArray(array $row): self

--- a/src/Provider/Doctrine/Auditing/Transaction/AuditTrait.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/AuditTrait.php
@@ -161,9 +161,9 @@ trait AuditTrait
      * Returns an array describing an entity.
      *
      * @param null|mixed $entity
-     * @param null|mixed $id
+     * @param array $extra
      */
-    private function summarize(EntityManagerInterface $entityManager, $entity = null, $id = null): ?array
+    private function summarize(EntityManagerInterface $entityManager, $entity = null, array $extra = []): ?array
     {
         if (null === $entity) {
             return null;
@@ -186,7 +186,7 @@ trait AuditTrait
             'class' => $meta->name,
             'label' => $label,
             'table' => $meta->getTableName(),
-        ];
+        ] + $extra;
     }
 
     /**

--- a/src/Provider/Doctrine/Auditing/Transaction/TransactionProcessor.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/TransactionProcessor.php
@@ -71,6 +71,8 @@ class TransactionProcessor implements TransactionProcessorInterface
     private function update(EntityManagerInterface $entityManager, object $entity, array $ch, string $transactionHash): void
     {
         $diff = $this->diff($entityManager, $entity, $ch);
+        unset($diff['@source']);
+
         if (0 === \count($diff)) {
             return; // if there is no entity diff, do not log it
         }
@@ -100,7 +102,7 @@ class TransactionProcessor implements TransactionProcessorInterface
         $this->audit([
             'action' => 'remove',
             'blame' => $this->blame(),
-            'diff' => $this->summarize($entityManager, $entity, $id),
+            'diff' => $this->summarize($entityManager, $entity, ['id' => $id]),
             'table' => $meta->getTableName(),
             'schema' => $meta->getSchemaName(),
             'id' => $id,
@@ -177,8 +179,8 @@ class TransactionProcessor implements TransactionProcessorInterface
             'action' => $type,
             'blame' => $this->blame(),
             'diff' => [
-                'source' => $this->summarize($entityManager, $source),
-                'target' => $this->summarize($entityManager, $target),
+                'source' => $this->summarize($entityManager, $source, ['field' => $mapping['fieldName']]),
+                'target' => $this->summarize($entityManager, $target, ['field' => $mapping['isOwningSide'] ? $mapping['inversedBy'] : $mapping['mappedBy']]),
                 'is_owning_side' => $mapping['isOwningSide'],
             ],
             'table' => $meta->getTableName(),

--- a/tests/Provider/Doctrine/Auditing/Transaction/TransactionProcessorTest.php
+++ b/tests/Provider/Doctrine/Auditing/Transaction/TransactionProcessorTest.php
@@ -215,12 +215,14 @@ final class TransactionProcessorTest extends TestCase
             'is_owning_side' => false,
             'source' => [
                 'class' => Author::class,
+                'field' => 'posts',
                 'id' => 1,
                 'label' => Author::class.'#1',
                 'table' => $entityManager->getClassMetadata(Author::class)->getTableName(),
             ],
             'target' => [
                 'class' => Post::class,
+                'field' => 'author',
                 'id' => 1,
                 'label' => (string) $post,
                 'table' => $entityManager->getClassMetadata(Post::class)->getTableName(),
@@ -287,12 +289,14 @@ final class TransactionProcessorTest extends TestCase
             'is_owning_side' => false,
             'source' => [
                 'class' => Author::class,
+                'field' => 'posts',
                 'id' => 1,
                 'label' => Author::class.'#1',
                 'table' => $entityManager->getClassMetadata(Author::class)->getTableName(),
             ],
             'target' => [
                 'class' => Post::class,
+                'field' => 'author',
                 'id' => 1,
                 'label' => (string) $post,
                 'table' => $entityManager->getClassMetadata(Post::class)->getTableName(),
@@ -406,6 +410,7 @@ final class TransactionProcessorTest extends TestCase
             'is_owning_side' => true,
             'source' => [
                 'class' => Post::class,
+                'field' => 'tags',
                 'id' => 1,
                 'label' => (string) $post,
                 'table' => $entityManager->getClassMetadata(Post::class)->getTableName(),
@@ -413,6 +418,7 @@ final class TransactionProcessorTest extends TestCase
             'table' => 'post__tag',
             'target' => [
                 'class' => Tag::class,
+                'field' => 'posts',
                 'id' => 2,
                 'label' => Tag::class.'#2',
                 'table' => $entityManager->getClassMetadata(Tag::class)->getTableName(),
@@ -429,6 +435,7 @@ final class TransactionProcessorTest extends TestCase
             'is_owning_side' => true,
             'source' => [
                 'class' => Post::class,
+                'field' => 'tags',
                 'id' => 1,
                 'label' => (string) $post,
                 'table' => $entityManager->getClassMetadata(Post::class)->getTableName(),
@@ -436,6 +443,7 @@ final class TransactionProcessorTest extends TestCase
             'table' => 'post__tag',
             'target' => [
                 'class' => Tag::class,
+                'field' => 'posts',
                 'id' => 1,
                 'label' => Tag::class.'#1',
                 'table' => $entityManager->getClassMetadata(Tag::class)->getTableName(),
@@ -552,6 +560,7 @@ final class TransactionProcessorTest extends TestCase
             'is_owning_side' => true,
             'source' => [
                 'class' => Post::class,
+                'field' => 'tags',
                 'id' => 1,
                 'label' => 'First post',
                 'table' => $entityManager->getClassMetadata(Post::class)->getTableName(),
@@ -559,6 +568,7 @@ final class TransactionProcessorTest extends TestCase
             'table' => 'post__tag',
             'target' => [
                 'class' => Tag::class,
+                'field' => 'posts',
                 'id' => 2,
                 'label' => Tag::class.'#2',
                 'table' => $entityManager->getClassMetadata(Tag::class)->getTableName(),


### PR DESCRIPTION
Keeps track of source and target relationship attributes involved in associate and dissociate operations (see issue #59)