### PR TITLE
External dev tools dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
-.DS_Store
 .idea/
+vendor/
+tests/coverage/
+.DS_Store
 .php_cs.cache
 .php-cs-fixer.cache
 .phpunit.result.cache
-/vendor/
 composer.lock
-/tests/coverage/
 *.sqlite

--- a/composer.json
+++ b/composer.json
@@ -34,13 +34,7 @@
     }
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.0",
     "gedmo/doctrine-extensions": "^2.4|^3.0",
-    "phpstan/phpstan": "^1.0",
-    "korbeil/phpstan-generic-rules": "^1.0",
-    "phpstan/phpstan-deprecation-rules": "^1.0",
-    "phpstan/phpstan-doctrine": "^1.0",
-    "phpstan/phpstan-strict-rules": "^1.0",
     "phpunit/phpunit": "^9.0",
     "symfony/var-dumper": "^4.0|^5.0"
   },
@@ -49,8 +43,8 @@
   },
   "scripts": {
     "test": "php -d pcov.enabled=1 ./vendor/bin/phpunit --colors=always",
-    "csfixer": "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --using-cache=no --verbose --ansi",
-    "stan": "vendor/bin/phpstan --ansi analyse src"
+    "csfixer": "tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --using-cache=no --verbose --ansi",
+    "phpstan": "tools/phpstan/vendor/bin/phpstan --ansi analyse src"
   },
   "config": {
     "sort-packages": true

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,6 @@
 includes:
-    - vendor/phpstan/phpstan-doctrine/extension.neon
-    - vendor/phpstan/phpstan-doctrine/rules.neon
+    - tools/phpstan/vendor/phpstan/phpstan-doctrine/extension.neon
+    - tools/phpstan/vendor/phpstan/phpstan-doctrine/rules.neon
 
 parameters:
     level: max

--- a/tools/php-cs-fixer/composer.json
+++ b/tools/php-cs-fixer/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "friendsofphp/php-cs-fixer": "^3.4"
+    }
+}

--- a/tools/phpstan/composer.json
+++ b/tools/phpstan/composer.json
@@ -1,0 +1,9 @@
+{
+    "require": {
+        "phpstan/phpstan": "^1.0",
+        "korbeil/phpstan-generic-rules": "^1.0",
+        "phpstan/phpstan-deprecation-rules": "^1.0",
+        "phpstan/phpstan-doctrine": "^1.0",
+        "phpstan/phpstan-strict-rules": "^1.0"
+    }
+}


### PR DESCRIPTION
Moved external dev tools (PHP-CS-Fixer and PHPStan) to a dedicated tools folder in order to remve them from "main" dependencies.