### PR TITLE
Fix incorrect dissociation array destructuring

### DIFF
--- a/src/Provider/Doctrine/Auditing/Transaction/TransactionHydrator.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/TransactionHydrator.php
@@ -102,6 +102,7 @@ class TransactionHydrator implements TransactionHydratorInterface
                         $transaction->trackAuditEvent(Transaction::DISSOCIATE, [
                             $collection->getOwner(),
                             $entity,
+                            $this->id($entityManager, $entity),
                             $mapping,
                         ]);
                     }

--- a/src/Provider/Doctrine/Auditing/Transaction/TransactionProcessor.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/TransactionProcessor.php
@@ -159,7 +159,7 @@ class TransactionProcessor implements TransactionProcessorInterface
 
     private function processDissociations(Transaction $transaction, EntityManagerInterface $entityManager): void
     {
-        foreach ($transaction->getDissociated() as [$source, $target, $mapping]) {
+        foreach ($transaction->getDissociated() as [$source, $target, $id, $mapping]) {
             $this->dissociate($entityManager, $source, $target, $mapping, $transaction->getTransactionHash());
         }
     }


### PR DESCRIPTION
Fixes https://github.com/DamienHarper/auditor/issues/91

All changes outside of src/Provider/Doctrine/Auditing/Transaction/TransactionProcessor.php are a result of running `composer csfixer`. Sorry for the clutter. 

FYI the test suite did not detect this problem, even though pcov shows the line covered. I didn't look into the reasons of that.