### PR TITLE
Switch from arrays to DTO classes when passing event information around

### DIFF
--- a/src/Event/Dto/AbstractAssociationEventDto.php
+++ b/src/Event/Dto/AbstractAssociationEventDto.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Event\Dto;
+
+abstract class AbstractAssociationEventDto extends AbstractEventDto
+{
+    private object $target;
+
+    private array $mapping;
+
+    public function __construct(object $source, object $target, array $mapping)
+    {
+        parent::__construct($source);
+
+        $this->target = $target;
+        $this->mapping = $mapping;
+    }
+
+    public function getTarget(): object
+    {
+        return $this->target;
+    }
+
+    public function getMapping(): array
+    {
+        return $this->mapping;
+    }
+}

--- a/src/Event/Dto/AbstractEventDto.php
+++ b/src/Event/Dto/AbstractEventDto.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Event\Dto;
+
+abstract class AbstractEventDto
+{
+    private object $source;
+
+    public function __construct(object $source)
+    {
+        $this->source = $source;
+    }
+
+    public function getSource(): object
+    {
+        return $this->source;
+    }
+}

--- a/src/Event/Dto/AssociateEventDto.php
+++ b/src/Event/Dto/AssociateEventDto.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Event\Dto;
+
+final class AssociateEventDto extends AbstractAssociationEventDto
+{
+    // No addition to the parent class.
+}

--- a/src/Event/Dto/DissociateEventDto.php
+++ b/src/Event/Dto/DissociateEventDto.php
@@ -6,28 +6,5 @@ namespace DH\Auditor\Event\Dto;
 
 final class DissociateEventDto extends AbstractAssociationEventDto
 {
-    /**
-     * @var mixed
-     */
-    private $id;
-
-    /**
-     * @param mixed $id
-     */
-    public function __construct(object $source, object $target, $id, array $mapping)
-    {
-        \assert(!empty($id));
-
-        parent::__construct($source, $target, $mapping);
-
-        $this->id = $id;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getId()
-    {
-        return $this->id;
-    }
+    // No addition to the parent class.
 }

--- a/src/Event/Dto/DissociateEventDto.php
+++ b/src/Event/Dto/DissociateEventDto.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Event\Dto;
+
+final class DissociateEventDto extends AbstractAssociationEventDto
+{
+    private $id;
+
+    public function __construct(object $source, object $target, $id, array $mapping)
+    {
+        \assert(!empty($id));
+
+        parent::__construct($source, $target, $mapping);
+
+        $this->id = $id;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/src/Event/Dto/DissociateEventDto.php
+++ b/src/Event/Dto/DissociateEventDto.php
@@ -6,8 +6,14 @@ namespace DH\Auditor\Event\Dto;
 
 final class DissociateEventDto extends AbstractAssociationEventDto
 {
+    /**
+     * @var mixed
+     */
     private $id;
 
+    /**
+     * @param mixed $id
+     */
     public function __construct(object $source, object $target, $id, array $mapping)
     {
         \assert(!empty($id));
@@ -17,6 +23,9 @@ final class DissociateEventDto extends AbstractAssociationEventDto
         $this->id = $id;
     }
 
+    /**
+     * @return mixed
+     */
     public function getId()
     {
         return $this->id;

--- a/src/Event/Dto/InsertEventDto.php
+++ b/src/Event/Dto/InsertEventDto.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Event\Dto;
+
+final class InsertEventDto extends AbstractEventDto
+{
+    private array $changeset;
+
+    public function __construct(object $source, array $changeset)
+    {
+        parent::__construct($source);
+
+        $this->changeset = $changeset;
+    }
+
+    public function getChangeset(): array
+    {
+        return $this->changeset;
+    }
+}

--- a/src/Event/Dto/RemoveEventDto.php
+++ b/src/Event/Dto/RemoveEventDto.php
@@ -6,14 +6,23 @@ namespace DH\Auditor\Event\Dto;
 
 final class RemoveEventDto extends AbstractEventDto
 {
+    /**
+     * @var mixed
+     */
     private $id;
 
+    /**
+     * @param mixed $id
+     */
     public function __construct(object $source, $id)
     {
         parent::__construct($source);
         $this->id = $id;
     }
 
+    /**
+     * @return mixed
+     */
     public function getId()
     {
         return $this->id;

--- a/src/Event/Dto/RemoveEventDto.php
+++ b/src/Event/Dto/RemoveEventDto.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Event\Dto;
+
+final class RemoveEventDto extends AbstractEventDto
+{
+    private $id;
+
+    public function __construct(object $source, $id)
+    {
+        parent::__construct($source);
+        $this->id = $id;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/src/Event/Dto/UpdateEventDto.php
+++ b/src/Event/Dto/UpdateEventDto.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Event\Dto;
+
+final class UpdateEventDto extends AbstractEventDto
+{
+    private array $changeset;
+
+    public function __construct(object $source, array $changeset)
+    {
+        parent::__construct($source);
+
+        $this->changeset = $changeset;
+    }
+
+    public function getChangeset(): array
+    {
+        return $this->changeset;
+    }
+}

--- a/src/Model/Transaction.php
+++ b/src/Model/Transaction.php
@@ -96,6 +96,8 @@ class Transaction implements TransactionInterface
     }
 
     /**
+     * @internal
+     *
      * @deprecated use one of the insert/update/remove/associate/dissociate methods instead
      */
     public function trackAuditEvent(string $type, array $data): void

--- a/src/Model/Transaction.php
+++ b/src/Model/Transaction.php
@@ -143,6 +143,9 @@ class Transaction implements TransactionInterface
         $this->updated[] = new UpdateEventDto($source, $changeset);
     }
 
+    /**
+     * @param mixed $id
+     */
     public function remove(object $source, $id): void
     {
         $this->removed[] = new RemoveEventDto($source, $id);
@@ -153,6 +156,9 @@ class Transaction implements TransactionInterface
         $this->associated[] = new AssociateEventDto($source, $target, $mapping);
     }
 
+    /**
+     * @param mixed $id
+     */
     public function dissociate(object $source, object $target, $id, array $mapping): void
     {
         $this->dissociated[] = new DissociateEventDto($source, $target, $id, $mapping);

--- a/src/Model/Transaction.php
+++ b/src/Model/Transaction.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace DH\Auditor\Model;
 
+use DH\Auditor\Event\Dto\AssociateEventDto;
+use DH\Auditor\Event\Dto\DissociateEventDto;
+use DH\Auditor\Event\Dto\InsertEventDto;
+use DH\Auditor\Event\Dto\RemoveEventDto;
+use DH\Auditor\Event\Dto\UpdateEventDto;
+
 /**
  * @see \DH\Auditor\Tests\Model\TransactionTest
  */
@@ -17,11 +23,30 @@ class Transaction implements TransactionInterface
 
     private ?string $transaction_hash = null;
 
-    private array $inserted = [];     // [$source, $changeset]
-    private array $updated = [];      // [$source, $changeset]
-    private array $removed = [];      // [$source, $id]
-    private array $associated = [];   // [$source, $target, $mapping]
-    private array $dissociated = [];  // [$source, $target, $id, $mapping]
+    /**
+     * @var InsertEventDto[]
+     */
+    private array $inserted = [];
+
+    /**
+     * @var UpdateEventDto[]
+     */
+    private array $updated = [];
+
+    /**
+     * @var RemoveEventDto[]
+     */
+    private array $removed = [];
+
+    /**
+     * @var AssociateEventDto[]
+     */
+    private array $associated = [];
+
+    /**
+     * @var DissociateEventDto[]
+     */
+    private array $dissociated = [];
 
     /**
      * Returns transaction hash.
@@ -70,33 +95,66 @@ class Transaction implements TransactionInterface
         $this->dissociated = [];
     }
 
+    /**
+     * @deprecated use one of the insert/update/remove/associate/dissociate methods instead
+     */
     public function trackAuditEvent(string $type, array $data): void
     {
         switch ($type) {
             case self::INSERT:
-                $this->inserted[] = $data;
+                \assert(2 === \count($data));
+                $this->insert(...$data);
 
                 break;
 
             case self::UPDATE:
-                $this->updated[] = $data;
+                \assert(2 === \count($data));
+                $this->update(...$data);
 
                 break;
 
             case self::REMOVE:
-                $this->removed[] = $data;
+                \assert(2 === \count($data));
+                $this->remove(...$data);
 
                 break;
 
             case self::ASSOCIATE:
-                $this->associated[] = $data;
+                \assert(3 === \count($data));
+                $this->associate(...$data);
 
                 break;
 
             case self::DISSOCIATE:
-                $this->dissociated[] = $data;
+                \assert(4 === \count($data));
+                $this->dissociate(...$data);
 
                 break;
         }
+    }
+
+    public function insert(object $source, array $changeset): void
+    {
+        $this->inserted[] = new InsertEventDto($source, $changeset);
+    }
+
+    public function update(object $source, array $changeset): void
+    {
+        $this->updated[] = new UpdateEventDto($source, $changeset);
+    }
+
+    public function remove(object $source, $id): void
+    {
+        $this->removed[] = new RemoveEventDto($source, $id);
+    }
+
+    public function associate(object $source, object $target, array $mapping): void
+    {
+        $this->associated[] = new AssociateEventDto($source, $target, $mapping);
+    }
+
+    public function dissociate(object $source, object $target, $id, array $mapping): void
+    {
+        $this->dissociated[] = new DissociateEventDto($source, $target, $id, $mapping);
     }
 }

--- a/src/Model/Transaction.php
+++ b/src/Model/Transaction.php
@@ -100,6 +100,8 @@ class Transaction implements TransactionInterface
      */
     public function trackAuditEvent(string $type, array $data): void
     {
+        @trigger_error('This method is deprecated, use one of the Transaction::insert(), Transaction::update(), Transaction::remove(), Transaction::associate(), Transaction::dissociate() methods instead.', E_USER_DEPRECATED);
+
         switch ($type) {
             case self::INSERT:
                 \assert(2 === \count($data));
@@ -156,11 +158,8 @@ class Transaction implements TransactionInterface
         $this->associated[] = new AssociateEventDto($source, $target, $mapping);
     }
 
-    /**
-     * @param mixed $id
-     */
-    public function dissociate(object $source, object $target, $id, array $mapping): void
+    public function dissociate(object $source, object $target, array $mapping): void
     {
-        $this->dissociated[] = new DissociateEventDto($source, $target, $id, $mapping);
+        $this->dissociated[] = new DissociateEventDto($source, $target, $mapping);
     }
 }

--- a/src/Provider/Doctrine/Auditing/Transaction/TransactionHydrator.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/TransactionHydrator.php
@@ -102,6 +102,7 @@ class TransactionHydrator implements TransactionHydratorInterface
                         $transaction->trackAuditEvent(Transaction::DISSOCIATE, [
                             $collection->getOwner(),
                             $entity,
+                            $this->id($entityManager, $entity),
                             $mapping,
                         ]);
                     }

--- a/src/Provider/Doctrine/Auditing/Transaction/TransactionHydrator.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/TransactionHydrator.php
@@ -80,16 +80,20 @@ class TransactionHydrator implements TransactionHydratorInterface
 
         /** @var PersistentCollection $collection */
         foreach (array_reverse($uow->getScheduledCollectionUpdates()) as $collection) {
-            /** @var object $owner */
             $owner = $collection->getOwner();
-            if ($this->provider->isAudited($owner)) {
+
+            if ($owner && $this->provider->isAudited($owner)) {
                 $mapping = $collection->getMapping();
+
+                if (null === $mapping) {
+                    continue;
+                }
 
                 /** @var object $entity */
                 foreach ($collection->getInsertDiff() as $entity) {
                     if ($this->provider->isAudited($entity)) {
                         $transaction->associate(
-                            $collection->getOwner(),
+                            $owner,
                             $entity,
                             $mapping,
                         );
@@ -98,9 +102,9 @@ class TransactionHydrator implements TransactionHydratorInterface
 
                 /** @var object $entity */
                 foreach ($collection->getDeleteDiff() as $entity) {
-                    if ($this->provider->isAudited($entity)) {
+                    if ($this->provider->isAudited($entity) && $collection->getOwner()) {
                         $transaction->dissociate(
-                            $collection->getOwner(),
+                            $owner,
                             $entity,
                             $this->id($entityManager, $entity),
                             $mapping,
@@ -117,16 +121,20 @@ class TransactionHydrator implements TransactionHydratorInterface
 
         /** @var PersistentCollection $collection */
         foreach (array_reverse($uow->getScheduledCollectionDeletions()) as $collection) {
-            /** @var object $owner */
             $owner = $collection->getOwner();
-            if ($this->provider->isAudited($owner)) {
+
+            if ($owner && $this->provider->isAudited($owner)) {
                 $mapping = $collection->getMapping();
+
+                if (null === $mapping) {
+                    continue;
+                }
 
                 /** @var object $entity */
                 foreach ($collection->toArray() as $entity) {
                     if ($this->provider->isAudited($entity)) {
                         $transaction->dissociate(
-                            $collection->getOwner(),
+                            $owner,
                             $entity,
                             $this->id($entityManager, $entity),
                             $mapping,

--- a/src/Provider/Doctrine/Auditing/Transaction/TransactionHydrator.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/TransactionHydrator.php
@@ -39,10 +39,10 @@ class TransactionHydrator implements TransactionHydratorInterface
         $uow = $entityManager->getUnitOfWork();
         foreach (array_reverse($uow->getScheduledEntityInsertions()) as $entity) {
             if ($this->provider->isAudited($entity)) {
-                $transaction->trackAuditEvent(Transaction::INSERT, [
+                $transaction->insert(
                     $entity,
                     $uow->getEntityChangeSet($entity),
-                ]);
+                );
             }
         }
     }
@@ -52,10 +52,10 @@ class TransactionHydrator implements TransactionHydratorInterface
         $uow = $entityManager->getUnitOfWork();
         foreach (array_reverse($uow->getScheduledEntityUpdates()) as $entity) {
             if ($this->provider->isAudited($entity)) {
-                $transaction->trackAuditEvent(Transaction::UPDATE, [
+                $transaction->update(
                     $entity,
                     $uow->getEntityChangeSet($entity),
-                ]);
+                );
             }
         }
     }
@@ -66,10 +66,10 @@ class TransactionHydrator implements TransactionHydratorInterface
         foreach (array_reverse($uow->getScheduledEntityDeletions()) as $entity) {
             if ($this->provider->isAudited($entity)) {
                 $uow->initializeObject($entity);
-                $transaction->trackAuditEvent(Transaction::REMOVE, [
+                $transaction->remove(
                     $entity,
                     $this->id($entityManager, $entity),
-                ]);
+                );
             }
         }
     }
@@ -88,23 +88,23 @@ class TransactionHydrator implements TransactionHydratorInterface
                 /** @var object $entity */
                 foreach ($collection->getInsertDiff() as $entity) {
                     if ($this->provider->isAudited($entity)) {
-                        $transaction->trackAuditEvent(Transaction::ASSOCIATE, [
+                        $transaction->associate(
                             $collection->getOwner(),
                             $entity,
                             $mapping,
-                        ]);
+                        );
                     }
                 }
 
                 /** @var object $entity */
                 foreach ($collection->getDeleteDiff() as $entity) {
                     if ($this->provider->isAudited($entity)) {
-                        $transaction->trackAuditEvent(Transaction::DISSOCIATE, [
+                        $transaction->dissociate(
                             $collection->getOwner(),
                             $entity,
                             $this->id($entityManager, $entity),
                             $mapping,
-                        ]);
+                        );
                     }
                 }
             }
@@ -125,11 +125,12 @@ class TransactionHydrator implements TransactionHydratorInterface
                 /** @var object $entity */
                 foreach ($collection->toArray() as $entity) {
                     if ($this->provider->isAudited($entity)) {
-                        $transaction->trackAuditEvent(Transaction::DISSOCIATE, [
+                        $transaction->dissociate(
                             $collection->getOwner(),
                             $entity,
+                            $this->id($entityManager, $entity),
                             $mapping,
-                        ]);
+                        );
                     }
                 }
             }

--- a/src/Provider/Doctrine/Auditing/Transaction/TransactionHydrator.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/TransactionHydrator.php
@@ -82,7 +82,7 @@ class TransactionHydrator implements TransactionHydratorInterface
         foreach (array_reverse($uow->getScheduledCollectionUpdates()) as $collection) {
             $owner = $collection->getOwner();
 
-            if ($owner && $this->provider->isAudited($owner)) {
+            if (null !== $owner && $this->provider->isAudited($owner)) {
                 $mapping = $collection->getMapping();
 
                 if (null === $mapping) {
@@ -106,7 +106,6 @@ class TransactionHydrator implements TransactionHydratorInterface
                         $transaction->dissociate(
                             $owner,
                             $entity,
-                            $this->id($entityManager, $entity),
                             $mapping,
                         );
                     }
@@ -123,7 +122,7 @@ class TransactionHydrator implements TransactionHydratorInterface
         foreach (array_reverse($uow->getScheduledCollectionDeletions()) as $collection) {
             $owner = $collection->getOwner();
 
-            if ($owner && $this->provider->isAudited($owner)) {
+            if (null !== $owner && $this->provider->isAudited($owner)) {
                 $mapping = $collection->getMapping();
 
                 if (null === $mapping) {
@@ -136,7 +135,6 @@ class TransactionHydrator implements TransactionHydratorInterface
                         $transaction->dissociate(
                             $owner,
                             $entity,
-                            $this->id($entityManager, $entity),
                             $mapping,
                         );
                     }

--- a/src/Provider/Doctrine/Auditing/Transaction/TransactionProcessor.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/TransactionProcessor.php
@@ -133,41 +133,41 @@ class TransactionProcessor implements TransactionProcessorInterface
     private function processInsertions(Transaction $transaction, EntityManagerInterface $entityManager): void
     {
         $uow = $entityManager->getUnitOfWork();
-        foreach ($transaction->getInserted() as [$entity, $ch]) {
+        foreach ($transaction->getInserted() as $dto) {
             // the changeset might be updated from UOW extra updates
-            $ch = array_merge($ch, $uow->getEntityChangeSet($entity));
-            $this->insert($entityManager, $entity, $ch, $transaction->getTransactionHash());
+            $ch = array_merge($dto->getChangeset(), $uow->getEntityChangeSet($dto->getSource()));
+            $this->insert($entityManager, $dto->getSource(), $ch, $transaction->getTransactionHash());
         }
     }
 
     private function processUpdates(Transaction $transaction, EntityManagerInterface $entityManager): void
     {
         $uow = $entityManager->getUnitOfWork();
-        foreach ($transaction->getUpdated() as [$entity, $ch]) {
+        foreach ($transaction->getUpdated() as $dto) {
             // the changeset might be updated from UOW extra updates
-            $ch = array_merge($ch, $uow->getEntityChangeSet($entity));
-            $this->update($entityManager, $entity, $ch, $transaction->getTransactionHash());
+            $ch = array_merge($dto->getChangeset(), $uow->getEntityChangeSet($dto->getSource()));
+            $this->update($entityManager, $dto->getSource(), $ch, $transaction->getTransactionHash());
         }
     }
 
     private function processAssociations(Transaction $transaction, EntityManagerInterface $entityManager): void
     {
-        foreach ($transaction->getAssociated() as [$source, $target, $mapping]) {
-            $this->associate($entityManager, $source, $target, $mapping, $transaction->getTransactionHash());
+        foreach ($transaction->getAssociated() as $dto) {
+            $this->associate($entityManager, $dto->getSource(), $dto->getTarget(), $dto->getMapping(), $transaction->getTransactionHash());
         }
     }
 
     private function processDissociations(Transaction $transaction, EntityManagerInterface $entityManager): void
     {
-        foreach ($transaction->getDissociated() as [$source, $target, $id, $mapping]) {
-            $this->dissociate($entityManager, $source, $target, $mapping, $transaction->getTransactionHash());
+        foreach ($transaction->getDissociated() as $dto) {
+            $this->dissociate($entityManager, $dto->getSource(), $dto->getTarget(), $dto->getMapping(), $transaction->getTransactionHash());
         }
     }
 
     private function processDeletions(Transaction $transaction, EntityManagerInterface $entityManager): void
     {
-        foreach ($transaction->getRemoved() as [$entity, $id]) {
-            $this->remove($entityManager, $entity, $id, $transaction->getTransactionHash());
+        foreach ($transaction->getRemoved() as $dto) {
+            $this->remove($entityManager, $dto->getSource(), $dto->getId(), $transaction->getTransactionHash());
         }
     }
 

--- a/src/Provider/Doctrine/Auditing/Transaction/TransactionProcessor.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/TransactionProcessor.php
@@ -159,7 +159,7 @@ class TransactionProcessor implements TransactionProcessorInterface
 
     private function processDissociations(Transaction $transaction, EntityManagerInterface $entityManager): void
     {
-        foreach ($transaction->getDissociated() as [$source, $target, $mapping]) {
+        foreach ($transaction->getDissociated() as [$source, $target, $id, $mapping]) {
             $this->dissociate($entityManager, $source, $target, $mapping, $transaction->getTransactionHash());
         }
     }

--- a/tests/Provider/Doctrine/Auditing/Transaction/TransactionProcessorTest.php
+++ b/tests/Provider/Doctrine/Auditing/Transaction/TransactionProcessorTest.php
@@ -598,13 +598,13 @@ final class TransactionProcessorTest extends TestCase
             ->setEmail('john.doe@gmail.com')
         ;
 
-        $transaction->trackAuditEvent(Transaction::INSERT, [
+        $transaction->insert(
             $author,
             [
                 'fullname' => [null, 'John Doe'],
                 'email' => [null, 'john.doe@gmail.com'],
             ],
-        ]);
+        );
 
         $processor->process($transaction);
 
@@ -630,13 +630,13 @@ final class TransactionProcessorTest extends TestCase
             ->setEmail('john.doze@gmail.com')
         ;
 
-        $transaction->trackAuditEvent(Transaction::UPDATE, [
+        $transaction->update(
             $author,
             [
                 'fullname' => ['John Doe', 'John Doze'],
                 'email' => ['john.doe@gmail.com', 'john.doze@gmail.com'],
             ],
-        ]);
+        );
 
         $processor->process($transaction);
 
@@ -645,10 +645,10 @@ final class TransactionProcessorTest extends TestCase
 
         $transaction->reset();
 
-        $transaction->trackAuditEvent(Transaction::UPDATE, [
+        $transaction->update(
             $author,
             [],
-        ]);
+        );
 
         $processor->process($transaction);
 
@@ -704,11 +704,11 @@ final class TransactionProcessorTest extends TestCase
             'isCascadeDetach' => false,
         ];
 
-        $transaction->trackAuditEvent(Transaction::ASSOCIATE, [
+        $transaction->associate(
             $author,
             $post,
             $mapping,
-        ]);
+        );
 
         $processor->process($transaction);
 
@@ -761,11 +761,12 @@ final class TransactionProcessorTest extends TestCase
             'isCascadeDetach' => false,
         ];
 
-        $transaction->trackAuditEvent(Transaction::DISSOCIATE, [
+        $transaction->dissociate(
             $author,
             $post,
+            $post->getId(),
             $mapping,
-        ]);
+        );
 
         $processor->process($transaction);
 
@@ -791,10 +792,10 @@ final class TransactionProcessorTest extends TestCase
             ->setEmail('john.doe@gmail.com')
         ;
 
-        $transaction->trackAuditEvent(Transaction::REMOVE, [
+        $transaction->remove(
             $author,
             1,
-        ]);
+        );
 
         $processor->process($transaction);
 

--- a/tests/Provider/Doctrine/Auditing/Transaction/TransactionProcessorTest.php
+++ b/tests/Provider/Doctrine/Auditing/Transaction/TransactionProcessorTest.php
@@ -764,7 +764,6 @@ final class TransactionProcessorTest extends TestCase
         $transaction->dissociate(
             $author,
             $post,
-            $post->getId(),
             $mapping,
         );
 


### PR DESCRIPTION
Followup to https://github.com/DamienHarper/auditor/issues/91#issuecomment-1064327898, here is the PR that uses DTO classes instead of arrays in order to improve code robustness.

I added a dedicated method to each event type. It expands the `Transaction` API surface a bit, but it also enables static code analysers to do their thing. Comparing to passing an array with vague structure that's later magically converted to something useful, I think the surface expansion is an acceptable cost to pay.