### PR TITLE
Write test for column of type `blob`.

### DIFF
--- a/src/Provider/Doctrine/Auditing/Transaction/AuditTrait.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/AuditTrait.php
@@ -106,6 +106,7 @@ trait AuditTrait
 
                 break;
 
+            case DoctrineHelper::getDoctrineType('BLOB'):
             case DoctrineHelper::getDoctrineType('BINARY'):
                 if (\is_resource($value)) {
                     // let's replace resources with a "simple" representation: resourceType#resourceId

--- a/tests/Provider/Doctrine/Fixtures/Issue98/Issue98.php
+++ b/tests/Provider/Doctrine/Fixtures/Issue98/Issue98.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Tests\Provider\Doctrine\Fixtures\Issue98;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="issue_98")
+ */
+#[ORM\Entity, ORM\Table(name: 'data_object')]
+class Issue98
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer", options={"unsigned": true})
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    #[ORM\Id, ORM\GeneratedValue(strategy: 'IDENTITY'), ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    protected $id;
+
+    /**
+     * @ORM\Column(type="blob")
+     */
+    #[ORM\Column(type: 'blob')]
+    protected $data;
+
+    /**
+     * Get the value of id.
+     *
+     * @return mixed
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set the value of id.
+     *
+     * @return DataObject
+     */
+    public function setId(int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of data.
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * Set the value of data.
+     *
+     * @param mixed $data
+     *
+     * @return DataObject
+     */
+    public function setData($data): self
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+}

--- a/tests/Provider/Doctrine/Issues/Issue98Test.php
+++ b/tests/Provider/Doctrine/Issues/Issue98Test.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Tests\Provider\Doctrine\Issues;
+
+use DH\Auditor\Model\Transaction;
+use DH\Auditor\Provider\Doctrine\DoctrineProvider;
+use DH\Auditor\Provider\Doctrine\Service\AuditingService;
+use DH\Auditor\Provider\Doctrine\Service\StorageService;
+use DH\Auditor\Provider\Service\StorageServiceInterface;
+use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Issue98\Issue98;
+use DH\Auditor\Tests\Provider\Doctrine\Traits\ReaderTrait;
+use DH\Auditor\Tests\Provider\Doctrine\Traits\Schema\SchemaSetupTrait;
+use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @small
+ */
+final class Issue98Test extends TestCase
+{
+    use ReaderTrait;
+    use SchemaSetupTrait;
+
+    public function testIssue98(): void
+    {
+        $reader = $this->createReader();
+
+        $em = $this->provider->getStorageServiceForEntity(Issue98::class)->getEntityManager();
+        $entity = new Issue98();
+        $entity->setData(fopen('data://text/plain,true', 'rb'));
+        $em->persist($entity);
+        $em->flush();
+
+        $audits = $reader->createQuery(Issue98::class)->execute();
+        self::assertCount(1, $audits, 'results count ok.');
+        self::assertSame(Transaction::INSERT, $audits[0]->getType(), 'Reader::INSERT operation.');
+    }
+
+    private function createAndInitDoctrineProvider(): void
+    {
+        $auditor = $this->createAuditor();
+        $this->provider = new DoctrineProvider($this->createProviderConfiguration());
+
+        $entityManager = $this->createEntityManager([
+            __DIR__.'/../../../../src/Provider/Doctrine/Auditing/Annotation',
+            __DIR__.'/../Fixtures/Issue98',
+        ]);
+        $this->provider->registerStorageService(new StorageService('default', $entityManager));
+        $this->provider->registerAuditingService(new AuditingService('default', $entityManager));
+
+        $auditor->registerProvider($this->provider);
+    }
+
+    private function configureEntities(): void
+    {
+        $this->provider->getConfiguration()->setEntities([
+            Issue98::class => ['enabled' => true],
+        ]);
+    }
+}

--- a/tests/Provider/Doctrine/Issues/Issue98Test.php
+++ b/tests/Provider/Doctrine/Issues/Issue98Test.php
@@ -8,11 +8,9 @@ use DH\Auditor\Model\Transaction;
 use DH\Auditor\Provider\Doctrine\DoctrineProvider;
 use DH\Auditor\Provider\Doctrine\Service\AuditingService;
 use DH\Auditor\Provider\Doctrine\Service\StorageService;
-use DH\Auditor\Provider\Service\StorageServiceInterface;
 use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Issue98\Issue98;
 use DH\Auditor\Tests\Provider\Doctrine\Traits\ReaderTrait;
 use DH\Auditor\Tests\Provider\Doctrine\Traits\Schema\SchemaSetupTrait;
-use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -31,7 +29,7 @@ final class Issue98Test extends TestCase
 
         $em = $this->provider->getStorageServiceForEntity(Issue98::class)->getEntityManager();
         $entity = new Issue98();
-        $entity->setData(fopen('data://text/plain,true', 'rb'));
+        $entity->setData(fopen('data://text/plain,true', 'r'));
         $em->persist($entity);
         $em->flush();
 


### PR DESCRIPTION
Written a test for #98.

@DamienHarper In the current case, the `blob` column type can be used for various elements, for instance, 'simple' fields like true/false, float values, or complete base64 encoded files. I think that it's not very useful to store the complete diff for cases like these. What do you think this project ought to do with these column types?