### PR TITLE
Add pkName::summarize to AuditTrait

### DIFF
--- a/src/Provider/Doctrine/Auditing/Transaction/AuditTrait.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/AuditTrait.php
@@ -209,9 +209,12 @@ trait AuditTrait
             $label = DoctrineHelper::getRealClassName($entity).(null === $pkValue ? '' : '#'.$pkValue);
         }
 
+        if ($pkName !== 'id') {
+            $extra['pkName'] = $pkName;
+        }
+
         return [
             $pkName => $pkValue,
-            'pkName' => $pkName,
             'class' => $meta->name,
             'label' => $label,
             'table' => $meta->getTableName(),

--- a/src/Provider/Doctrine/Auditing/Transaction/AuditTrait.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/AuditTrait.php
@@ -209,7 +209,7 @@ trait AuditTrait
             $label = DoctrineHelper::getRealClassName($entity).(null === $pkValue ? '' : '#'.$pkValue);
         }
 
-        if ($pkName !== 'id') {
+        if ('id' !== $pkName) {
             $extra['pkName'] = $pkName;
         }
 

--- a/src/Provider/Doctrine/Auditing/Transaction/AuditTrait.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/AuditTrait.php
@@ -211,6 +211,7 @@ trait AuditTrait
 
         return [
             $pkName => $pkValue,
+            'pkName' => $pkName,
             'class' => $meta->name,
             'label' => $label,
             'table' => $meta->getTableName(),

--- a/tests/Provider/Doctrine/Fixtures/Issue112/DummyEntity.php
+++ b/tests/Provider/Doctrine/Fixtures/Issue112/DummyEntity.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Tests\Provider\Doctrine\Fixtures\Issue112;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="author")
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'author')]
+class DummyEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer", options={"unsigned": true})
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    protected int $primaryKey;
+
+    public function getPrimaryKey(): int
+    {
+        return $this->primaryKey;
+    }
+
+    public function setPrimaryKey(int $primaryKey): void
+    {
+        $this->primaryKey = $primaryKey;
+    }
+}

--- a/tests/Provider/Doctrine/Issues/Issue112Test.php
+++ b/tests/Provider/Doctrine/Issues/Issue112Test.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Tests\Provider\Doctrine\Issues;
+
+use DH\Auditor\Provider\Doctrine\Auditing\Transaction\AuditTrait;
+use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Issue112\DummyEntity;
+use DH\Auditor\Tests\Provider\Doctrine\Traits\Schema\DefaultSchemaSetupTrait;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @small
+ */
+final class Issue112Test extends TestCase
+{
+    use AuditTrait;
+    use DefaultSchemaSetupTrait;
+
+    /**
+     * @throws \Doctrine\ORM\Mapping\MappingException
+     * @throws \Doctrine\DBAL\Exception
+     * @throws \DH\Auditor\Exception\MappingException
+     */
+    public function testSummarizeWithUnusualPK(): void
+    {
+        $entityManager = $this->createEntityManager();
+        $entity = new DummyEntity();
+        $entity->setPrimaryKey(2);
+        $data = $this->summarize($entityManager, $entity);
+        self::assertSame('primaryKey', $data['pkName']);
+    }
+}


### PR DESCRIPTION
To fix #112 I need to make 2 PRs.
1. Auditor PR - added pkName to ’summarize’ method to possible detect primary key. After entity is stored, impossible to get the key, it can be changed, it used directy in twig template and so on
2. Have a new tag of this package
3. Auditor-bundle PR - fix  helper.twig::summarize method and use the field. https://github.com/DamienHarper/auditor-bundle/pull/328

Also I added an Entity I'll use in Auditor-bundle - it's primary key is not `id`. Needed to write test where.