### PR TITLE
Include schema in auditable table names

### DIFF
--- a/src/Provider/Doctrine/Persistence/Schema/SchemaManager.php
+++ b/src/Provider/Doctrine/Persistence/Schema/SchemaManager.php
@@ -69,7 +69,15 @@ class SchemaManager
         $audited = [];
         foreach ($entities as $entity) {
             if ($this->provider->isAuditable($entity)) {
-                $audited[$entity] = $entityManager->getClassMetadata($entity)->getTableName();
+                $metadata = $entityManager->getClassMetadata($entity);
+
+                // PostgreSQL allows tables to be placed in non-default DB schema
+                // See https://www.doctrine-project.org/projects/doctrine-orm/en/2.13/reference/attributes-reference.html#attrref_table
+                if ($metadata->getSchemaName()) {
+                    $audited[$entity] = $metadata->getSchemaName().'.'.$metadata->getTableName();
+                } else {
+                    $audited[$entity] = $metadata->getTableName();
+                }
             }
         }
         ksort($audited);


### PR DESCRIPTION
PostgreSQL (and some others, but not MySQL) has a concept of multiple schemas in a single database. Doctrine [supports this](https://www.doctrine-project.org/projects/doctrine-orm/en/2.13/reference/attributes-reference.html#attrref_table).

This PR fixes a problem when running `audit:clean` tried to remove things from audited tables, but `SchemaManager::getAuditableTableNames()` didn't account for the schema name.

This change prepends the schema name when found. I'm not convinced this is the only place this behaviour should change, but it's a start - it fixed the problem for me, allowing `ClanAuditLogCommand::computeAuditTablename()` to compile the correct name. 

Return value before:

```
array:36 [
  "App\Entity\Address" => "address"
  "App\Entity\Feed" => "feed"
  "App\Entity\FeedContent" => "feed_content"
...
```

Return value after:

```
array:36 [
  "App\Entity\Address" => "core.address"
  "App\Entity\Feed" => "core.feed"
  "App\Entity\FeedContent" => "core.feed_content"
...
```

