### PR TITLE
Deprecation of Doctrine\DBAL\Logging\SQLLogger Interface #113

### DIFF
--- a/src/Provider/Doctrine/Auditing/Logger/Middleware/DHConnection.php
+++ b/src/Provider/Doctrine/Auditing/Logger/Middleware/DHConnection.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Provider\Doctrine\Auditing\Logger\Middleware;
+
+use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\ParameterType;
+
+/**
+ * @interal
+ */
+final class DHConnection implements ConnectionInterface
+{
+    private ConnectionInterface $connection;
+    private DHDriver $DHDriver;
+
+    public function __construct(ConnectionInterface $connection, DHDriver $DHDriver)
+    {
+        $this->connection = $connection;
+        $this->DHDriver = $DHDriver;
+    }
+
+    public function prepare(string $sql): Statement
+    {
+        return $this->connection->prepare($sql);
+    }
+
+    public function query(string $sql): Result
+    {
+        return $this->connection->query($sql);
+    }
+
+    public function quote($value, $type = ParameterType::STRING)
+    {
+        return $this->connection->quote($value, $type);
+    }
+
+    public function exec(string $sql): int
+    {
+        return $this->connection->exec($sql);
+    }
+
+    public function lastInsertId($name = null)
+    {
+        return $this->connection->lastInsertId($name);
+    }
+
+    public function beginTransaction(): bool
+    {
+        return $this->connection->beginTransaction();
+    }
+
+    public function commit(): bool
+    {
+        $flusherList = $this->DHDriver->getFlusherList();
+        foreach ($flusherList as $flusher) {
+            ($flusher)();
+        }
+        $this->DHDriver->resetDHFlusherList();
+
+        return $this->connection->commit();
+    }
+
+    public function rollBack(): bool
+    {
+        $this->DHDriver->resetDHFlusherList();
+
+        return $this->connection->rollBack();
+    }
+
+    /**
+     * @return object|resource
+     */
+    public function getNativeConnection()
+    {
+        return $this->connection->getNativeConnection();
+    }
+}

--- a/src/Provider/Doctrine/Auditing/Logger/Middleware/DHConnection.php
+++ b/src/Provider/Doctrine/Auditing/Logger/Middleware/DHConnection.php
@@ -5,52 +5,19 @@ declare(strict_types=1);
 namespace DH\Auditor\Provider\Doctrine\Auditing\Logger\Middleware;
 
 use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
-use Doctrine\DBAL\Driver\Result;
-use Doctrine\DBAL\Driver\Statement;
-use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
 
 /**
  * @interal
  */
-final class DHConnection implements ConnectionInterface
+final class DHConnection extends AbstractConnectionMiddleware
 {
-    private ConnectionInterface $connection;
     private DHDriver $DHDriver;
 
     public function __construct(ConnectionInterface $connection, DHDriver $DHDriver)
     {
-        $this->connection = $connection;
+        parent::__construct($connection);
         $this->DHDriver = $DHDriver;
-    }
-
-    public function prepare(string $sql): Statement
-    {
-        return $this->connection->prepare($sql);
-    }
-
-    public function query(string $sql): Result
-    {
-        return $this->connection->query($sql);
-    }
-
-    public function quote($value, $type = ParameterType::STRING)
-    {
-        return $this->connection->quote($value, $type);
-    }
-
-    public function exec(string $sql): int
-    {
-        return $this->connection->exec($sql);
-    }
-
-    public function lastInsertId($name = null)
-    {
-        return $this->connection->lastInsertId($name);
-    }
-
-    public function beginTransaction(): bool
-    {
-        return $this->connection->beginTransaction();
     }
 
     public function commit(): bool
@@ -61,21 +28,13 @@ final class DHConnection implements ConnectionInterface
         }
         $this->DHDriver->resetDHFlusherList();
 
-        return $this->connection->commit();
+        return parent::commit();
     }
 
     public function rollBack(): bool
     {
         $this->DHDriver->resetDHFlusherList();
 
-        return $this->connection->rollBack();
-    }
-
-    /**
-     * @return object|resource
-     */
-    public function getNativeConnection()
-    {
-        return $this->connection->getNativeConnection();
+        return parent::rollBack();
     }
 }

--- a/src/Provider/Doctrine/Auditing/Logger/Middleware/DHDriver.php
+++ b/src/Provider/Doctrine/Auditing/Logger/Middleware/DHDriver.php
@@ -4,27 +4,22 @@ declare(strict_types=1);
 
 namespace DH\Auditor\Provider\Doctrine\Auditing\Logger\Middleware;
 
-use Doctrine\DBAL\Connection as DBALConnection;
-use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Driver as DriverInterface;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
 
 /**
  * @interal
  */
-final class DHDriver implements DriverInterface
+final class DHDriver extends AbstractDriverMiddleware
 {
     private DriverInterface $driver;
 
     /** @var array<callable> */
     private array $flusherList = [];
 
-    /**
-     * @internal this driver can be only instantiated by its middleware
-     */
     public function __construct(DriverInterface $driver)
     {
+        parent::__construct($driver);
         $this->driver = $driver;
     }
 
@@ -37,27 +32,6 @@ final class DHDriver implements DriverInterface
             $this->driver->connect($params),
             $this
         );
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getDatabasePlatform(): AbstractPlatform
-    {
-        return $this->driver->getDatabasePlatform();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getSchemaManager(DBALConnection $conn, AbstractPlatform $platform): AbstractSchemaManager
-    {
-        return $this->driver->getSchemaManager($conn, $platform);
-    }
-
-    public function getExceptionConverter(): ExceptionConverter
-    {
-        return $this->driver->getExceptionConverter();
     }
 
     public function addDHFlusher(callable $flusher): void

--- a/src/Provider/Doctrine/Auditing/Logger/Middleware/DHDriver.php
+++ b/src/Provider/Doctrine/Auditing/Logger/Middleware/DHDriver.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Provider\Doctrine\Auditing\Logger\Middleware;
+
+use Doctrine\DBAL\Connection as DBALConnection;
+use Doctrine\DBAL\Driver\API\ExceptionConverter;
+use Doctrine\DBAL\Driver as DriverInterface;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+
+/**
+ * @interal
+ */
+final class DHDriver implements DriverInterface
+{
+    private DriverInterface $driver;
+
+    /** @var array<callable> */
+    private array $flusherList = [];
+
+    /**
+     * @internal this driver can be only instantiated by its middleware
+     */
+    public function __construct(DriverInterface $driver)
+    {
+        $this->driver = $driver;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function connect(array $params)
+    {
+        return new DHConnection(
+            $this->driver->connect($params),
+            $this
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDatabasePlatform(): AbstractPlatform
+    {
+        return $this->driver->getDatabasePlatform();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getSchemaManager(DBALConnection $conn, AbstractPlatform $platform): AbstractSchemaManager
+    {
+        return $this->driver->getSchemaManager($conn, $platform);
+    }
+
+    public function getExceptionConverter(): ExceptionConverter
+    {
+        return $this->driver->getExceptionConverter();
+    }
+
+    public function addDHFlusher(callable $flusher): void
+    {
+        $this->flusherList[] = $flusher;
+    }
+
+    public function resetDHFlusherList(): void
+    {
+        $this->flusherList = [];
+    }
+
+    public function getFlusherList(): array
+    {
+        return $this->flusherList;
+    }
+}

--- a/src/Provider/Doctrine/Auditing/Logger/Middleware/DHMiddleware.php
+++ b/src/Provider/Doctrine/Auditing/Logger/Middleware/DHMiddleware.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Provider\Doctrine\Auditing\Logger\Middleware;
+
+use Doctrine\DBAL\Driver as BaseDriver;
+use Doctrine\DBAL\Driver\Middleware as MiddlewareInterface;
+
+final class DHMiddleware implements MiddlewareInterface
+{
+    public function wrap(BaseDriver $driver): BaseDriver
+    {
+        return new DHDriver($driver);
+    }
+}

--- a/src/Provider/Doctrine/Auditing/Transaction/TransactionHydrator.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/TransactionHydrator.php
@@ -27,11 +27,12 @@ class TransactionHydrator implements TransactionHydratorInterface
      */
     public function hydrate(TransactionInterface $transaction): void
     {
-        $this->hydrateWithScheduledInsertions($transaction, $transaction->getEntityManager());
-        $this->hydrateWithScheduledUpdates($transaction, $transaction->getEntityManager());
-        $this->hydrateWithScheduledDeletions($transaction, $transaction->getEntityManager());
-        $this->hydrateWithScheduledCollectionUpdates($transaction, $transaction->getEntityManager());
-        $this->hydrateWithScheduledCollectionDeletions($transaction, $transaction->getEntityManager());
+        $em = $transaction->getEntityManager();
+        $this->hydrateWithScheduledInsertions($transaction, $em);
+        $this->hydrateWithScheduledUpdates($transaction, $em);
+        $this->hydrateWithScheduledDeletions($transaction, $em);
+        $this->hydrateWithScheduledCollectionUpdates($transaction, $em);
+        $this->hydrateWithScheduledCollectionDeletions($transaction, $em);
     }
 
     private function hydrateWithScheduledInsertions(Transaction $transaction, EntityManagerInterface $entityManager): void

--- a/src/Provider/Doctrine/Auditing/Transaction/TransactionProcessor.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/TransactionProcessor.php
@@ -35,11 +35,12 @@ class TransactionProcessor implements TransactionProcessorInterface
      */
     public function process(TransactionInterface $transaction): void
     {
-        $this->processInsertions($transaction, $transaction->getEntityManager());
-        $this->processUpdates($transaction, $transaction->getEntityManager());
-        $this->processAssociations($transaction, $transaction->getEntityManager());
-        $this->processDissociations($transaction, $transaction->getEntityManager());
-        $this->processDeletions($transaction, $transaction->getEntityManager());
+        $em = $transaction->getEntityManager();
+        $this->processInsertions($transaction, $em);
+        $this->processUpdates($transaction, $em);
+        $this->processAssociations($transaction, $em);
+        $this->processDissociations($transaction, $em);
+        $this->processDeletions($transaction, $em);
     }
 
     private function notify(array $payload): void

--- a/tests/Provider/Doctrine/Traits/ConnectionTrait.php
+++ b/tests/Provider/Doctrine/Traits/ConnectionTrait.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DH\Auditor\Tests\Provider\Doctrine\Traits;
 
-use DH\Auditor\Provider\Doctrine\Persistence\Helper\DoctrineHelper;
 use DH\Auditor\Provider\Doctrine\Auditing\Logger\Middleware\DHMiddleware;
+use DH\Auditor\Provider\Doctrine\Persistence\Helper\DoctrineHelper;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;


### PR DESCRIPTION
Related #113 
Also fixes `$args->getEntityManager();` method deprecated

Inspired from https://github.com/symfony/symfony/tree/6.2/src/Symfony/Bridge/Doctrine/Middleware/Debug
It's first part to done #113, because we need to do extra in auditor-bundle to add Middleware to Connection

@DamienHarper please do not merge before I'll complete a second PR, but you can review