### PR TITLE
Fix some deprecations

### DIFF
--- a/src/Provider/Doctrine/Auditing/Logger/Middleware/DHDriver.php
+++ b/src/Provider/Doctrine/Auditing/Logger/Middleware/DHDriver.php
@@ -26,7 +26,7 @@ final class DHDriver extends AbstractDriverMiddleware
     /**
      * {@inheritDoc}
      */
-    public function connect(array $params)
+    public function connect(array $params): DHConnection
     {
         return new DHConnection(
             $this->driver->connect($params),

--- a/src/Provider/Doctrine/Persistence/Command/CleanAuditLogsCommand.php
+++ b/src/Provider/Doctrine/Persistence/Command/CleanAuditLogsCommand.php
@@ -15,7 +15,6 @@ use DH\Auditor\Provider\Doctrine\Service\AuditingService;
 use DH\Auditor\Provider\Doctrine\Service\StorageService;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Exception;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\LockableTrait;
 use Symfony\Component\Console\Helper\ProgressBar;

--- a/src/Provider/Doctrine/Persistence/Command/CleanAuditLogsCommand.php
+++ b/src/Provider/Doctrine/Persistence/Command/CleanAuditLogsCommand.php
@@ -52,8 +52,8 @@ class CleanAuditLogsCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('audit:clean')
             ->setDescription('Cleans audit tables')
+            ->setName('audit:clean')
             ->addOption('no-confirm', null, InputOption::VALUE_NONE, 'No interaction mode')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do not execute SQL queries.')
             ->addOption('dump-sql', null, InputOption::VALUE_NONE, 'Prints SQL related queries.')

--- a/src/Provider/Doctrine/Persistence/Command/CleanAuditLogsCommand.php
+++ b/src/Provider/Doctrine/Persistence/Command/CleanAuditLogsCommand.php
@@ -28,7 +28,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * @see \DH\Auditor\Tests\Provider\Doctrine\Persistence\Command\CleanAuditLogsCommandTest
  */
-#[AsCommand('audit:clean')]
 class CleanAuditLogsCommand extends Command
 {
     use LockableTrait;

--- a/src/Provider/Doctrine/Persistence/Command/CleanAuditLogsCommand.php
+++ b/src/Provider/Doctrine/Persistence/Command/CleanAuditLogsCommand.php
@@ -15,6 +15,7 @@ use DH\Auditor\Provider\Doctrine\Service\AuditingService;
 use DH\Auditor\Provider\Doctrine\Service\StorageService;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Exception;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\LockableTrait;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -27,13 +28,12 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * @see \DH\Auditor\Tests\Provider\Doctrine\Persistence\Command\CleanAuditLogsCommandTest
  */
+#[AsCommand('audit:clean')]
 class CleanAuditLogsCommand extends Command
 {
     use LockableTrait;
 
     private const UNTIL_DATE_FORMAT = 'Y-m-d H:i:s';
-
-    protected static $defaultName = 'audit:clean';
 
     private Auditor $auditor;
 
@@ -52,8 +52,8 @@ class CleanAuditLogsCommand extends Command
     protected function configure(): void
     {
         $this
+            ->setName('audit:clean')
             ->setDescription('Cleans audit tables')
-            ->setName(self::$defaultName) // @phpstan-ignore-line
             ->addOption('no-confirm', null, InputOption::VALUE_NONE, 'No interaction mode')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do not execute SQL queries.')
             ->addOption('dump-sql', null, InputOption::VALUE_NONE, 'Prints SQL related queries.')

--- a/src/Provider/Doctrine/Persistence/Command/UpdateSchemaCommand.php
+++ b/src/Provider/Doctrine/Persistence/Command/UpdateSchemaCommand.php
@@ -7,7 +7,6 @@ namespace DH\Auditor\Provider\Doctrine\Persistence\Command;
 use DH\Auditor\Auditor;
 use DH\Auditor\Provider\Doctrine\DoctrineProvider;
 use DH\Auditor\Provider\Doctrine\Persistence\Schema\SchemaManager;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\LockableTrait;
 use Symfony\Component\Console\Helper\ProgressBar;

--- a/src/Provider/Doctrine/Persistence/Command/UpdateSchemaCommand.php
+++ b/src/Provider/Doctrine/Persistence/Command/UpdateSchemaCommand.php
@@ -19,7 +19,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * @see \DH\Auditor\Tests\Provider\Doctrine\Persistence\Command\UpdateSchemaCommandTest
  */
-#[AsCommand('audit:schema:update')]
 class UpdateSchemaCommand extends Command
 {
     use LockableTrait;

--- a/src/Provider/Doctrine/Persistence/Command/UpdateSchemaCommand.php
+++ b/src/Provider/Doctrine/Persistence/Command/UpdateSchemaCommand.php
@@ -7,6 +7,7 @@ namespace DH\Auditor\Provider\Doctrine\Persistence\Command;
 use DH\Auditor\Auditor;
 use DH\Auditor\Provider\Doctrine\DoctrineProvider;
 use DH\Auditor\Provider\Doctrine\Persistence\Schema\SchemaManager;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\LockableTrait;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -18,11 +19,10 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * @see \DH\Auditor\Tests\Provider\Doctrine\Persistence\Command\UpdateSchemaCommandTest
  */
+#[AsCommand('audit:schema:update')]
 class UpdateSchemaCommand extends Command
 {
     use LockableTrait;
-
-    protected static $defaultName = 'audit:schema:update';
 
     private Auditor $auditor;
 
@@ -44,7 +44,7 @@ class UpdateSchemaCommand extends Command
             ->setDescription('Update audit tables structure')
             ->addOption('dump-sql', null, InputOption::VALUE_NONE, 'Dumps the generated SQL statements to the screen (does not execute them).')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Causes the generated SQL statements to be physically executed against your database.')
-            ->setName(self::$defaultName) // @phpstan-ignore-line
+            ->setName('audit:schema:update')
         ;
     }
 

--- a/src/Provider/Doctrine/Persistence/Command/UpdateSchemaCommand.php
+++ b/src/Provider/Doctrine/Persistence/Command/UpdateSchemaCommand.php
@@ -42,9 +42,9 @@ class UpdateSchemaCommand extends Command
     {
         $this
             ->setDescription('Update audit tables structure')
+            ->setName('audit:schema:update')
             ->addOption('dump-sql', null, InputOption::VALUE_NONE, 'Dumps the generated SQL statements to the screen (does not execute them).')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Causes the generated SQL statements to be physically executed against your database.')
-            ->setName('audit:schema:update')
         ;
     }
 


### PR DESCRIPTION
- `Method "Doctrine\DBAL\Driver::connect()" might add "DriverConnection" as a native return type declaration in the future. Do the same in implementation "DH\Auditor\Provider\Doctrine\Auditing\Logger\Middleware\DHDriver" now to avoid errors or add an explicit @return annotation to suppress this message`
- `The "Symfony\Component\Console\Command\Command::$defaultName" property is considered final. You should not override it in "DH\Auditor\Provider\Doctrine\Persistence\Command\CleanAuditLogsCommand"`