### PR TITLE
DoctrineHelper::createAnnotationMetadataConfiguration not resolving vendor folder correctly

### DIFF
--- a/src/Provider/Doctrine/Persistence/Helper/DoctrineHelper.php
+++ b/src/Provider/Doctrine/Persistence/Helper/DoctrineHelper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DH\Auditor\Provider\Doctrine\Persistence\Helper;
 
+use Composer\Autoload\ClassLoader;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
@@ -18,6 +19,7 @@ use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Tools\Setup;
 use InvalidArgumentException;
+use ReflectionClass;
 
 /**
  * @see \DH\Auditor\Tests\Provider\Doctrine\Persistence\Helper\DoctrineHelperTest
@@ -145,7 +147,7 @@ final class DoctrineHelper
     public static function createAnnotationMetadataConfiguration(array $paths, bool $isDevMode = false): Configuration
     {
         if (class_exists(ORMSetup::class)) {
-            require_once __DIR__.'/../../../../../vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php';
+            require_once self::getVendorDir().'/doctrine/orm/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php';
 
             return ORMSetup::createAnnotationMetadataConfiguration($paths, $isDevMode);
         }
@@ -156,5 +158,12 @@ final class DoctrineHelper
     public static function getEntityManagerFromOnFlushEventArgs(OnFlushEventArgs $args): EntityManagerInterface
     {
         return method_exists($args, 'getObjectManager') ? $args->getObjectManager() : $args->getEntityManager();
+    }
+
+    public static function getVendorDir(): string
+    {
+        $reflection = new ReflectionClass(ClassLoader::class);
+
+        return \dirname($reflection->getFileName(), 2);
     }
 }

--- a/src/Provider/Doctrine/Persistence/Helper/DoctrineHelper.php
+++ b/src/Provider/Doctrine/Persistence/Helper/DoctrineHelper.php
@@ -163,7 +163,9 @@ final class DoctrineHelper
     public static function getVendorDir(): string
     {
         $reflection = new ReflectionClass(ClassLoader::class);
+        $filename = $reflection->getFileName();
+        \assert(\is_string($filename));
 
-        return \dirname($reflection->getFileName(), 2);
+        return \dirname($filename, 2);
     }
 }


### PR DESCRIPTION
Fixes DoctrineHelper::createAnnotationMetadataConfiguration not resolving vendor path properly while testing `auditor-bundle`.
@DamienHarper  I need a new `patch` tag

https://github.com/DamienHarper/auditor-bundle/actions/runs/3455733853/jobs/5767964253