### PR TITLE
Multiple schemas support

### DIFF
--- a/src/Model/Transaction.php
+++ b/src/Model/Transaction.php
@@ -96,6 +96,8 @@ class Transaction implements TransactionInterface
     }
 
     /**
+     * TODO: remove for next major release.
+     *
      * @internal
      *
      * @deprecated use one of the insert/update/remove/associate/dissociate methods instead

--- a/src/Provider/Doctrine/Auditing/Annotation/AnnotationLoader.php
+++ b/src/Provider/Doctrine/Auditing/Annotation/AnnotationLoader.php
@@ -45,6 +45,7 @@ class AnnotationLoader
         $reflection = $metadata->getReflectionClass();
 
         // Check that we have an Entity annotation or attribute
+        // TODO: only rely on PHP attributes for next major release
         $attributes = \PHP_VERSION_ID >= 80000 && method_exists($reflection, 'getAttributes') ? $reflection->getAttributes(Entity::class) : null;
         if (\is_array($attributes) && \count($attributes) > 0) {
             $annotation = $attributes[0]->newInstance();
@@ -57,6 +58,7 @@ class AnnotationLoader
         }
 
         // Check that we have an Auditable annotation or attribute
+        // TODO: only rely on PHP attributes for next major release
         $attributes = \PHP_VERSION_ID >= 80000 && method_exists($reflection, 'getAttributes') ? $reflection->getAttributes(Auditable::class) : null;
         if (\is_array($attributes) && \count($attributes) > 0) {
             $auditableAnnotation = $attributes[0]->newInstance();
@@ -69,6 +71,7 @@ class AnnotationLoader
         }
 
         // Check that we have a Security annotation or attribute
+        // TODO: only rely on PHP attributes for next major release
         $attributes = \PHP_VERSION_ID >= 80000 && method_exists($reflection, 'getAttributes') ? $reflection->getAttributes(Security::class) : null;
         if (\is_array($attributes) && \count($attributes) > 0) {
             $securityAnnotation = $attributes[0]->newInstance();
@@ -94,6 +97,7 @@ class AnnotationLoader
         $properties = [];
 
         foreach ($reflection->getProperties() as $property) {
+            // TODO: only rely on PHP attributes for next major release
             $attributes = \PHP_VERSION_ID >= 80000 && method_exists($property, 'getAttributes') ? $property->getAttributes(Ignore::class) : null;
             if (\is_array($attributes) && \count($attributes) > 0) {
                 $annotationProperty = $attributes[0]->newInstance();

--- a/src/Provider/Doctrine/DoctrineProvider.php
+++ b/src/Provider/Doctrine/DoctrineProvider.php
@@ -13,6 +13,7 @@ use DH\Auditor\Provider\Doctrine\Auditing\Annotation\AnnotationLoader;
 use DH\Auditor\Provider\Doctrine\Auditing\Event\DoctrineSubscriber;
 use DH\Auditor\Provider\Doctrine\Auditing\Transaction\TransactionManager;
 use DH\Auditor\Provider\Doctrine\Persistence\Event\CreateSchemaListener;
+use DH\Auditor\Provider\Doctrine\Persistence\Event\TableSchemaSubscriber;
 use DH\Auditor\Provider\Doctrine\Persistence\Helper\DoctrineHelper;
 use DH\Auditor\Provider\Doctrine\Service\AuditingService;
 use DH\Auditor\Provider\Doctrine\Service\StorageService;
@@ -47,6 +48,7 @@ class DoctrineProvider extends AbstractProvider
         $evm = $entityManager->getEventManager();
 
         // Register subscribers
+        $evm->addEventSubscriber(new TableSchemaSubscriber($this));
         $evm->addEventSubscriber(new CreateSchemaListener($this));
         $evm->addEventSubscriber(new DoctrineSubscriber($this->transactionManager));
 
@@ -252,13 +254,8 @@ class DoctrineProvider extends AbstractProvider
     {
         \assert($this->configuration instanceof Configuration);   // helps PHPStan
         if (null === $this->configuration->getStorageMapper() && $this->isStorageMapperRequired()) {
-            throw new ProviderException('You must provide a mapper function to map audits to storage.');
+            throw new ProviderException('You must provide a mapper callback to map audits to storage.');
         }
-
-//        if (null === $this->getStorageMapper() && 1 === count($this->getStorageServices())) {
-//            // No mapper and only 1 storage entity manager
-//            return array_values($this->storageServices)[0];
-//        }
 
         return $this;
     }

--- a/src/Provider/Doctrine/Persistence/Command/CleanAuditLogsCommand.php
+++ b/src/Provider/Doctrine/Persistence/Command/CleanAuditLogsCommand.php
@@ -11,7 +11,6 @@ use DH\Auditor\Provider\Doctrine\Configuration;
 use DH\Auditor\Provider\Doctrine\DoctrineProvider;
 use DH\Auditor\Provider\Doctrine\Persistence\Helper\DoctrineHelper;
 use DH\Auditor\Provider\Doctrine\Persistence\Schema\SchemaManager;
-use DH\Auditor\Provider\Doctrine\Service\AuditingService;
 use DH\Auditor\Provider\Doctrine\Service\StorageService;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Exception;
@@ -84,15 +83,17 @@ class CleanAuditLogsCommand extends Command
         /** @var StorageService[] $storageServices */
         $storageServices = $provider->getStorageServices();
 
-        // auditable entities by storage entity manager
-        $repository = [];
+        // auditable classes by storage entity manager
         $count = 0;
 
-        // Collect auditable entities from auditing storage managers
-        [$repository, $count] = $this->collectAuditableEntities($provider, $schemaManager, $repository, $count);
+        // Collect auditable classes from auditing storage managers
+        $repository = $schemaManager->collectAuditableEntities();
+        foreach ($repository as $name => $entities) {
+            $count += \count($entities);
+        }
 
         $message = sprintf(
-            "You are about to clean audits created before <comment>%s</comment>: %d entities involved.\n Do you want to proceed?",
+            "You are about to clean audits created before <comment>%s</comment>: %d classes involved.\n Do you want to proceed?",
             $until->format(self::UNTIL_DATE_FORMAT),
             $count
         );
@@ -104,6 +105,7 @@ class CleanAuditLogsCommand extends Command
         if ($confirm) {
             /** @var Configuration $configuration */
             $configuration = $provider->getConfiguration();
+            $entities = $configuration->getEntities();
 
             $progressBar = new ProgressBar($output, $count);
             $progressBar->setBarWidth(70);
@@ -113,14 +115,15 @@ class CleanAuditLogsCommand extends Command
             $progressBar->start();
 
             $queries = [];
-            foreach ($repository as $name => $entities) {
-                foreach ($entities as $entity => $tablename) {
-                    $auditTable = $this->computeAuditTablename($tablename, $configuration);
+            foreach ($repository as $name => $classes) {
+                foreach ($classes as $entity => $tablename) {
+                    $connection = $storageServices[$name]->getEntityManager()->getConnection();
+                    $auditTable = $schemaManager->resolveAuditTableName($entities[$entity], $configuration, $connection->getDatabasePlatform());
 
                     /**
                      * @var QueryBuilder
                      */
-                    $queryBuilder = $storageServices[$name]->getEntityManager()->getConnection()->createQueryBuilder();
+                    $queryBuilder = $connection->createQueryBuilder();
                     $queryBuilder
                         ->delete($auditTable)
                         ->where('created_at < :until')
@@ -177,39 +180,5 @@ class CleanAuditLogsCommand extends Command
         }
 
         return (new DateTimeImmutable())->sub($dateInterval);
-    }
-
-    private function collectAuditableEntities(DoctrineProvider $provider, SchemaManager $schemaManager, array $repository, int $count): array
-    {
-        /** @var AuditingService[] $auditingServices */
-        $auditingServices = $provider->getAuditingServices();
-        foreach ($auditingServices as $name => $auditingService) {
-            $classes = $schemaManager->getAuditableTableNames($auditingService->getEntityManager());
-            // Populate the auditable entities repository
-            foreach ($classes as $entity => $tableName) {
-                $storageService = $provider->getStorageServiceForEntity($entity);
-                $key = array_search($storageService, $provider->getStorageServices(), true);
-                if (!isset($repository[$key])) {
-                    $repository[$key] = [];
-                }
-                $repository[$key][$entity] = $tableName;
-                ++$count;
-            }
-        }
-
-        return [$repository, $count];
-    }
-
-    private function computeAuditTablename(string $tablename, Configuration $configuration): ?string
-    {
-        return preg_replace(
-            sprintf('#^([^\.]+\.)?(%s)$#', preg_quote($tablename, '#')),
-            sprintf(
-                '$1%s$2%s',
-                preg_quote($configuration->getTablePrefix(), '#'),
-                preg_quote($configuration->getTableSuffix(), '#')
-            ),
-            $tablename
-        );
     }
 }

--- a/src/Provider/Doctrine/Persistence/Event/CreateSchemaListener.php
+++ b/src/Provider/Doctrine/Persistence/Event/CreateSchemaListener.php
@@ -66,7 +66,7 @@ class CreateSchemaListener implements EventSubscriber
             && array_values($auditingServices)[0]->getEntityManager() === array_values($storageServices)[0]->getEntityManager();
 
         $updater = new SchemaManager($this->provider);
-        $updater->createAuditTable($metadata->name, $eventArgs->getClassTable(), $isSameEntityManager ? $eventArgs->getSchema() : null);
+        $updater->createAuditTable($metadata->name, $isSameEntityManager ? $eventArgs->getSchema() : null);
     }
 
     /**

--- a/src/Provider/Doctrine/Persistence/Event/TableSchemaSubscriber.php
+++ b/src/Provider/Doctrine/Persistence/Event/TableSchemaSubscriber.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Provider\Doctrine\Persistence\Event;
+
+use DH\Auditor\Provider\Doctrine\DoctrineProvider;
+use DH\Auditor\Provider\Doctrine\Persistence\Schema\SchemaManager;
+use DH\Auditor\Provider\Doctrine\Service\StorageService;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+
+class TableSchemaSubscriber implements EventSubscriber
+{
+    private DoctrineProvider $provider;
+
+    public function __construct(DoctrineProvider $provider)
+    {
+        $this->provider = $provider;
+    }
+
+    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs): void
+    {
+        $classMetadata = $eventArgs->getClassMetadata();
+        if (!$classMetadata->isInheritanceTypeSingleTable() || $classMetadata->getName() === $classMetadata->rootEntityName) {
+            $schemaManager = new SchemaManager($this->provider);
+            $storageService = $this->provider->getStorageServiceForEntity($classMetadata->getName());
+
+            \assert($storageService instanceof StorageService);
+            $platform = $storageService->getEntityManager()->getConnection()->getDatabasePlatform();
+            if (!$platform->supportsSchemas()) {
+                $classMetadata->setPrimaryTable([
+                    'name' => $schemaManager->resolveTableName($classMetadata->getTableName(), $classMetadata->getSchemaName() ?? '', $platform),
+                    'schema' => '',
+                ]);
+            }
+        }
+    }
+
+    public function getSubscribedEvents()
+    {
+        return ['loadClassMetadata'];
+    }
+}

--- a/tests/Provider/Doctrine/Fixtures/Entity/Inheritance/Joined/Animal.php
+++ b/tests/Provider/Doctrine/Fixtures/Entity/Inheritance/Joined/Animal.php
@@ -8,12 +8,12 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
- * @ORM\Table(name="animal")
+ * @ORM\Table(name="animal", schema="auditor")
  * @ORM\InheritanceType("JOINED")
  * @ORM\DiscriminatorColumn(name="type", type="string")
  * @ORM\DiscriminatorMap({"cat": "Cat", "dog": "Dog"})
  */
-#[ORM\Entity, ORM\Table(name: 'animal'), ORM\InheritanceType('JOINED')]
+#[ORM\Entity, ORM\Table(name: 'animal', schema: 'auditor'), ORM\InheritanceType('JOINED')]
 #[ORM\DiscriminatorColumn(name: 'type', type: 'string')]
 #[ORM\DiscriminatorMap(['cat' => 'Cat', 'dog' => 'Dog'])]
 abstract class Animal

--- a/tests/Provider/Doctrine/Fixtures/Entity/Inheritance/Joined/Cat.php
+++ b/tests/Provider/Doctrine/Fixtures/Entity/Inheritance/Joined/Cat.php
@@ -8,9 +8,9 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
- * @ORM\Table(name="cat")
+ * @ORM\Table(name="cat", schema="auditor")
  */
-#[ORM\Entity, ORM\Table(name: 'cat')]
+#[ORM\Entity, ORM\Table(name: 'cat', schema: 'auditor')]
 class Cat extends Animal
 {
 }

--- a/tests/Provider/Doctrine/Fixtures/Entity/Inheritance/Joined/Dog.php
+++ b/tests/Provider/Doctrine/Fixtures/Entity/Inheritance/Joined/Dog.php
@@ -8,9 +8,9 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
- * @ORM\Table(name="dog")
+ * @ORM\Table(name="dog", schema="auditor")
  */
-#[ORM\Entity, ORM\Table(name: 'dog')]
+#[ORM\Entity, ORM\Table(name: 'dog', schema: 'auditor')]
 class Dog extends Animal
 {
 }

--- a/tests/Provider/Doctrine/Persistence/Event/CreateSchemaListenerTest.php
+++ b/tests/Provider/Doctrine/Persistence/Event/CreateSchemaListenerTest.php
@@ -6,10 +6,12 @@ namespace DH\Auditor\Tests\Provider\Doctrine\Persistence\Event;
 
 use DH\Auditor\Provider\Doctrine\Persistence\Helper\DoctrineHelper;
 use DH\Auditor\Provider\Doctrine\Service\StorageService;
+use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\Joined\Animal;
 use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\Joined\Cat;
 use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\Joined\Dog;
 use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\SingleTable\Bike;
 use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\SingleTable\Car;
+use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\SingleTable\Vehicle;
 use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Standard\Blog\Author;
 use DH\Auditor\Tests\Provider\Doctrine\Traits\Schema\DefaultSchemaSetupTrait;
 use PHPUnit\Framework\TestCase;
@@ -49,20 +51,23 @@ final class CreateSchemaListenerTest extends TestCase
      */
     public function testCorrectSchemaForJoinedTableInheritance(): void
     {
+        $configuration = $this->provider->getConfiguration();
+        $entities = $configuration->getEntities();
+        $classes = [Dog::class, Cat::class];
         $tableNames = $this->getTables();
 
-        self::assertContains('animal', $tableNames);
-        self::assertContains('dog', $tableNames);
-        self::assertContains('dog_audit', $tableNames);
-        self::assertContains('cat', $tableNames);
-        self::assertContains('cat_audit', $tableNames);
+        self::assertNotContains(Animal::class, $entities);
 
-        self::assertNotContains('animal_audit', $tableNames);
+        foreach ($classes as $entity) {
+            self::assertContains($entities[$entity]['computed_table_name'], $tableNames);
+            self::assertContains($entities[$entity]['computed_audit_table_name'], $tableNames);
+        }
     }
 
     private function configureEntities(): void
     {
         $this->provider->getConfiguration()->setEntities([
+            Vehicle::class => ['enabled' => true],
             Car::class => ['enabled' => true],
             Bike::class => ['enabled' => true],
 

--- a/tests/Provider/Doctrine/Persistence/Schema/SchemaManager1AEM2SEMTest.php
+++ b/tests/Provider/Doctrine/Persistence/Schema/SchemaManager1AEM2SEMTest.php
@@ -56,10 +56,20 @@ final class SchemaManager1AEM2SEMTest extends TestCase
     public function testSchemaSetup(): void
     {
         $storageServices = $this->provider->getStorageServices();
+        $configuration = $this->provider->getConfiguration();
+
         $expected = [
-            'db1' => ['author_audit', 'comment_audit', 'post_audit', 'tag_audit'],
-            'db2' => ['animal_audit', 'cat_audit', 'dog_audit', 'vehicle_audit'],
+            'db1' => [],
+            'db2' => [],
         ];
+        $entities = $configuration->getEntities();
+        foreach ($entities as $entity => $entityOptions) {
+            $key = \in_array($entity, [Author::class, Post::class, Comment::class, Tag::class], true) ? 'db1' : 'db2';
+
+            if (!\in_array($entityOptions['computed_audit_table_name'], $expected[$key], true)) {
+                $expected[$key][] = $entityOptions['computed_audit_table_name'];
+            }
+        }
         sort($expected['db1']);
         sort($expected['db2']);
 

--- a/tests/Provider/Doctrine/Persistence/Schema/SchemaManager2AEM1SEMTest.php
+++ b/tests/Provider/Doctrine/Persistence/Schema/SchemaManager2AEM1SEMTest.php
@@ -56,13 +56,21 @@ final class SchemaManager2AEM1SEMTest extends TestCase
     public function testSchemaSetup(): void
     {
         $storageServices = $this->provider->getStorageServices();
+        $configuration = $this->provider->getConfiguration();
 
         $expected = [
-            'sem1' => [
-                'author', 'author_audit', 'comment', 'comment_audit', 'post', 'post_audit', 'tag', 'tag_audit', 'post__tag',
-                'animal', 'animal_audit', 'cat', 'cat_audit', 'dog', 'dog_audit', 'vehicle', 'vehicle_audit',
-            ],
+            'sem1' => ['post__tag'],
         ];
+        $entities = $configuration->getEntities();
+        foreach ($entities as $entity => $entityOptions) {
+            if (!\in_array($entityOptions['computed_table_name'], $expected['sem1'], true)) {
+                $expected['sem1'][] = $entityOptions['computed_table_name'];
+            }
+
+            if (!\in_array($entityOptions['computed_audit_table_name'], $expected['sem1'], true)) {
+                $expected['sem1'][] = $entityOptions['computed_audit_table_name'];
+            }
+        }
         sort($expected['sem1']);
 
         /**

--- a/tests/Provider/Doctrine/Persistence/Schema/SchemaManagerTest.php
+++ b/tests/Provider/Doctrine/Persistence/Schema/SchemaManagerTest.php
@@ -15,6 +15,8 @@ use DH\Auditor\Provider\Doctrine\Service\StorageService;
 use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\Joined\Animal;
 use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\Joined\Cat;
 use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\Joined\Dog;
+use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\SingleTable\Bike;
+use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\SingleTable\Car;
 use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Inheritance\SingleTable\Vehicle;
 use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Standard\Blog\Author;
 use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Standard\Blog\Comment;
@@ -76,8 +78,8 @@ final class SchemaManagerTest extends TestCase
         self::assertNull($this->getTable($schemaManager->listTables(), 'author_audit'), 'author_audit does not exist yet.');
 
         // create audit table for Author entity
-        $authorTable = $this->getTable($schemaManager->listTables(), 'author');
-        $toSchema = $updater->createAuditTable(Author::class, $authorTable);
+        $this->doConfigureEntities();
+        $toSchema = $updater->createAuditTable(Author::class);
         $this->migrate($fromSchema, $toSchema, $entityManager, $storageConnection->getDatabasePlatform());
 
         // check audit table has been created
@@ -116,10 +118,11 @@ final class SchemaManagerTest extends TestCase
         $fromSchema = DoctrineHelper::introspectSchema($schemaManager);
 
         // at this point, schema is populated but does not contain any audit table
-        $authorTable = $this->getTable($schemaManager->listTables(), 'author');
+        self::assertNull($this->getTable($schemaManager->listTables(), 'author_audit'), 'author_audit does not exist yet.');
 
         // create audit table for Author entity
-        $toSchema = $updater->createAuditTable(Author::class, $authorTable);
+        $this->doConfigureEntities();
+        $toSchema = $updater->createAuditTable(Author::class);
         $this->migrate($fromSchema, $toSchema, $entityManager, $storageConnection->getDatabasePlatform());
 
         // new/alternate structure
@@ -253,9 +256,8 @@ final class SchemaManagerTest extends TestCase
 
         // run UpdateManager::updateAuditTable() to bring author_audit to expected structure
         $fromSchema = DoctrineHelper::introspectSchema($schemaManager);
-        $authorAuditTable = $this->getTable($schemaManager->listTables(), 'author_audit');
 
-        $toSchema = $updater->updateAuditTable(Author::class, $authorAuditTable);
+        $toSchema = $updater->updateAuditTable(Author::class);
         $this->migrate($fromSchema, $toSchema, $entityManager, $storageConnection->getDatabasePlatform());
 
         $authorAuditTable = $this->getTable($schemaManager->listTables(), 'author_audit');
@@ -323,5 +325,22 @@ final class SchemaManagerTest extends TestCase
         }
 
         return $provider;
+    }
+
+    private function doConfigureEntities(): void
+    {
+        $this->provider->getConfiguration()->setEntities([
+            Author::class => ['enabled' => true],
+            Post::class => ['enabled' => true],
+            Comment::class => ['enabled' => true],
+            Tag::class => ['enabled' => true],
+
+            Animal::class => ['enabled' => true],
+            Cat::class => ['enabled' => true],
+            Dog::class => ['enabled' => true],
+            Vehicle::class => ['enabled' => true],
+            Bike::class => ['enabled' => true],
+            Car::class => ['enabled' => true],
+        ]);
     }
 }

--- a/tests/Provider/Doctrine/Traits/ConnectionTrait.php
+++ b/tests/Provider/Doctrine/Traits/ConnectionTrait.php
@@ -62,8 +62,6 @@ trait ConnectionTrait
             $this->dropAndCreateDatabase($connection->createSchemaManager(), $dbname);
         }
 
-        $connection->close();
-
         return DriverManager::getConnection($params, $config);
     }
 

--- a/tests/Provider/Doctrine/Traits/DoctrineProviderTrait.php
+++ b/tests/Provider/Doctrine/Traits/DoctrineProviderTrait.php
@@ -66,49 +66,40 @@ trait DoctrineProviderTrait
         $auditor = $this->createAuditor();
         $provider = new DoctrineProvider($configuration ?? $this->createProviderConfiguration());
 
-        $db = self::getConnectionParameters();
-
         // Entity manager "db1" is used for storage only (db1 connection => db1.sqlite)
-//        if (!empty($db)) {
-//            $db['dbname'] = 'db1';
-//        } else {
-        $db = [
-            'driver' => 'pdo_sqlite',
-            'path' => __DIR__.'/../db1.sqlite',
-        ];
-//        }
-
         $provider->registerStorageService(new StorageService('db1', $this->createEntityManager([
             __DIR__.'/../../../../src/Provider/Doctrine/Auditing/Annotation',
             __DIR__.'/../Fixtures/Entity/Standard/Blog',
-        ], 'db1', $db)));
+        ], 'db1', [
+            'driver' => 'pdo_sqlite',
+            'path' => __DIR__.'/../db1.sqlite',
+        ])));
 
         // Entity manager "db2" is used for storage only (db2 connection => db2.sqlite)
-//        if (!empty($db)) {
-//            $db['dbname'] = 'db2';
-//        } else {
-        $db = [
-            'driver' => 'pdo_sqlite',
-            'path' => __DIR__.'/../db2.sqlite',
-        ];
-//        }
-
         $provider->registerStorageService(new StorageService('db2', $this->createEntityManager([
             __DIR__.'/../../../../src/Provider/Doctrine/Auditing/Annotation',
             __DIR__.'/../Fixtures/Entity/Inheritance',
-        ], 'db2', $db)));
+        ], 'db2', [
+            'driver' => 'pdo_sqlite',
+            'path' => __DIR__.'/../db2.sqlite',
+        ])));
 
         // Entity manager "aem1" is used for auditing only (default connection => in memory sqlite db)
         $provider->registerAuditingService(new AuditingService('aem1', $this->createEntityManager([
             __DIR__.'/../../../../src/Provider/Doctrine/Auditing/Annotation',
             __DIR__.'/../Fixtures/Entity/Standard/Blog',
             __DIR__.'/../Fixtures/Entity/Inheritance',
+        ], 'default', [
+            'driver' => 'pdo_sqlite',
+            'memory' => true,
         ])));
 
         $auditor->registerProvider($provider);
 
         // Set a storage mapper that maps entities to db1 or db2
-        $provider->getConfiguration()->setStorageMapper(static fn (string $entity, array $storageServices): StorageServiceInterface => \in_array($entity, [Author::class, Post::class, Comment::class, Tag::class], true) ? $storageServices['db1'] : $storageServices['db2']);
+        $provider->getConfiguration()->setStorageMapper(
+            static fn (string $entity, array $storageServices): StorageServiceInterface => \in_array($entity, [Author::class, Post::class, Comment::class, Tag::class], true) ? $storageServices['db1'] : $storageServices['db2']
+        );
 
         return $provider;
     }
@@ -122,24 +113,29 @@ trait DoctrineProviderTrait
         $auditor = $this->createAuditor();
         $provider = new DoctrineProvider($configuration ?? $this->createProviderConfiguration());
 
+        $params = [
+            'driver' => 'pdo_sqlite',
+            'memory' => true,
+        ];
+
         // Entity manager "sem1" is used for storage only (default connection => in memory sqlite db)
         $provider->registerStorageService(new StorageService('sem1', $this->createEntityManager([
             __DIR__.'/../../../../src/Provider/Doctrine/Auditing/Annotation',
             __DIR__.'/../Fixtures/Entity/Standard/Blog',
             __DIR__.'/../Fixtures/Entity/Inheritance',
-        ])));
+        ], 'default', $params)));
 
         // Entity manager "aem1" is used for auditing only (default connection => in memory sqlite db)
         $provider->registerAuditingService(new AuditingService('aem1', $this->createEntityManager([
             __DIR__.'/../../../../src/Provider/Doctrine/Auditing/Annotation',
             __DIR__.'/../Fixtures/Entity/Standard/Blog',
-        ])));
+        ], 'default', $params)));
 
         // Entity manager "aem2" is used for auditing only (default connection => in memory sqlite db)
         $provider->registerAuditingService(new AuditingService('aem2', $this->createEntityManager([
             __DIR__.'/../../../../src/Provider/Doctrine/Auditing/Annotation',
             __DIR__.'/../Fixtures/Entity/Inheritance',
-        ])));
+        ], 'default', $params)));
 
         $auditor->registerProvider($provider);
 
@@ -155,36 +151,32 @@ trait DoctrineProviderTrait
         $auditor = $this->createAuditor();
         $provider = new DoctrineProvider($configuration ?? $this->createProviderConfiguration());
 
-//        $db = self::getConnectionParameters();
-
-        // Entity manager "sem1" is used for storage only (db1 connection => db1.sqlite)
-//        if (!empty($db)) {
-//            $db['dbname'] = 'sem1';
-//        } else {
-        $db = [
+        $params = [
             'driver' => 'pdo_sqlite',
-            'path' => __DIR__.'/../sem1.sqlite',
+            'memory' => true,
         ];
-//        }
 
-        // Entity manager "sem1" is used for storage only (default connection => in memory sqlite db)
+        // Entity manager "sem1" is used for storage only (db1 connection => sem1.sqlite)
         $provider->registerStorageService(new StorageService('sem1', $this->createEntityManager([
             __DIR__.'/../../../../src/Provider/Doctrine/Auditing/Annotation',
             __DIR__.'/../Fixtures/Entity/Standard',
             __DIR__.'/../Fixtures/Entity/Inheritance',
-        ], 'sem1', $db)));
+        ], 'sem1', [
+            'driver' => 'pdo_sqlite',
+            'path' => __DIR__.'/../sem1.sqlite',
+        ])));
 
         // Entity manager "aem1" is used for auditing only (default connection => in memory sqlite db)
         $provider->registerAuditingService(new AuditingService('aem1', $this->createEntityManager([
             __DIR__.'/../../../../src/Provider/Doctrine/Auditing/Annotation',
             __DIR__.'/../Fixtures/Entity/Standard',
-        ])));
+        ], 'default', $params)));
 
         // Entity manager "aem2" is used for auditing only (default connection => in memory sqlite db)
         $provider->registerAuditingService(new AuditingService('aem2', $this->createEntityManager([
             __DIR__.'/../../../../src/Provider/Doctrine/Auditing/Annotation',
             __DIR__.'/../Fixtures/Entity/Inheritance',
-        ])));
+        ], 'default', $params)));
 
         $auditor->registerProvider($provider);
 


### PR DESCRIPTION
Some database vendors (PostgreSQL for example) support multiple schemas in a single database. Doctrine already natively [supports this](https://www.doctrine-project.org/projects/doctrine-orm/en/2.13/reference/attributes-reference.html#attrref_table).

This PR brings a better schema support to `auditor`

For example, let’s have an `Author` audited entity
```php
<?php

declare(strict_types=1);

namespace App\Entity;

use DH\Auditor\Provider\Doctrine\Auditing\Annotation as Audit;
use Doctrine\ORM\Mapping as ORM;

#[ORM\Entity, ORM\Table(name: 'author', schema: 'my_schema')]
#[Audit\Auditable]
class Author
{
  // ...
}
```

Here is how `auditor` works regarding schemas:
#### When using a database supporting schemas (eg. PostgreSQL)
- Entity metadata is untouched (includes table name and schema name)
- Doctrine then takes care of targeting the relevant schema when querying both the audited and audit tables (even creates schema if required)

Results: 
- audited table is named `author`
- audit table is named `author_audit` (by default, audit table are suffixed with `_audit`)
- `auditor` queries will target `my_schema.author_audit`

#### When using a database **NOT** supporting schemas (eg. MySQL)
- Entity metadata is altered to
  - remove schema name from metadata (MySQL would interpret the schema name as a database name for example)
  - prefix table name using the following rule: `[SCHEMA_NAME]__[TABLE_NAME]` 
- Doctrine then targets the current (single) schema/database when querying both the audited and audit tables 
    
Results: 
- audited table is named `my_schema__author`
- audit table is named `my_schema__author_audit` (by default, audit table are suffixed with `_audit`)
