### PR TITLE
Bugfix - Audit character encoding for arrays fails

### DIFF
--- a/src/Provider/Doctrine/Auditing/Transaction/TransactionProcessor.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/TransactionProcessor.php
@@ -209,7 +209,9 @@ class TransactionProcessor implements TransactionProcessorInterface
         $schema = $data['schema'] ? $data['schema'].'.' : '';
         $auditTable = $schema.$configuration->getTablePrefix().$data['table'].$configuration->getTableSuffix();
         $dt = new DateTimeImmutable('now', new DateTimeZone($this->provider->getAuditor()->getConfiguration()->getTimezone()));
-        $diff = \is_string($data['diff']) ? mb_convert_encoding($data['diff'], 'UTF-8', 'UTF-8') : $data['diff'];
+        $diff = $data['diff'];
+        $convertCharEncoding = (\is_string($diff) || \is_array($diff));
+        $diff = $convertCharEncoding ? mb_convert_encoding($diff, 'UTF-8', 'UTF-8') : $diff;
 
         $payload = [
             'entity' => $data['entity'],


### PR DESCRIPTION
When the diff is an array the character encoding may fail.
This pull request fixes this issue by character encoding array diffs too.