### PR TITLE
Clean Command: include, exclude entities and specify date

### DIFF
--- a/src/Provider/Doctrine/Persistence/Command/CleanAuditLogsCommand.php
+++ b/src/Provider/Doctrine/Persistence/Command/CleanAuditLogsCommand.php
@@ -56,6 +56,9 @@ class CleanAuditLogsCommand extends Command
             ->addOption('no-confirm', null, InputOption::VALUE_NONE, 'No interaction mode')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do not execute SQL queries.')
             ->addOption('dump-sql', null, InputOption::VALUE_NONE, 'Prints SQL related queries.')
+            ->addOption('exclude', 'x', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Entities to exclude from cleaning')
+            ->addOption('include', 'i', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Entities to include in cleaning')
+            ->addOption('date', 'd', InputOption::VALUE_OPTIONAL, 'Specify a custom date to clean audits until (must be expressed as an ISO 8601 date, e.g. 2023-04-24).')
             ->addArgument('keep', InputArgument::OPTIONAL, 'Audits retention period (must be expressed as an ISO 8601 date interval, e.g. P12M to keep the last 12 months or P7D to keep the last 7 days).', 'P12M')
         ;
     }
@@ -70,17 +73,29 @@ class CleanAuditLogsCommand extends Command
 
         $io = new SymfonyStyle($input, $output);
 
-        $keep = $input->getArgument('keep');
-        $keep = (\is_array($keep) ? $keep[0] : $keep);
+        $keep  = $input->getArgument('keep');
+        $keep  = (\is_array($keep) ? $keep[0] : $keep);
+        $date  = $input->getOption('date');
+        $until = null;
 
-        $until = $this->validateKeepArgument($keep, $io);
+        if ($date) {
+            // Use custom date if provided
+            try {
+                $until = new DateTimeImmutable($date);
+            } catch (Exception $e) {
+                $io->error(sprintf('Invalid date format provided: %s', $date));
+            }
+        } else {
+            // Fall back to default retention period
+            $until = $this->validateKeepArgument($keep, $io);
+        }
 
-        if (!$until instanceof DateTimeImmutable) {
+        if (null === $until) {
             return 0;
         }
 
         /** @var DoctrineProvider $provider */
-        $provider = $this->auditor->getProvider(DoctrineProvider::class);
+        $provider      = $this->auditor->getProvider(DoctrineProvider::class);
         $schemaManager = new SchemaManager($provider);
 
         /** @var StorageService[] $storageServices */
@@ -90,9 +105,29 @@ class CleanAuditLogsCommand extends Command
         $count = 0;
 
         // Collect auditable classes from auditing storage managers
-        $repository = $schemaManager->collectAuditableEntities();
-        foreach ($repository as $entities) {
-            $count += is_countable($entities) ? \count($entities) : 0;
+        $excludeEntities    = array_values($input->getOption('exclude') ?? []);
+        $includeEntities    = array_values($input->getOption('include') ?? []);
+        $repository         = $schemaManager->collectAuditableEntities();
+        $filteredRepository = [];
+
+        foreach ($repository as $name => $entityClasses) {
+            foreach ($entityClasses as $entityClass => $table) {
+                if (
+                    !in_array($entityClass, $excludeEntities) &&
+                    (
+                        empty($includeEntities) ||
+                        in_array($entityClass, $includeEntities)
+                    )
+                ) {
+                    $filteredRepository[$name][$entityClass] = $table;
+                }
+            }
+        }
+
+        $repository = $filteredRepository;
+
+        foreach ($repository as $name => $entities) {
+            $count += \count($entities);
         }
 
         $message = sprintf(

--- a/tests/Provider/Doctrine/Persistence/Command/CleanAuditLogsCommandTest.php
+++ b/tests/Provider/Doctrine/Persistence/Command/CleanAuditLogsCommandTest.php
@@ -111,6 +111,48 @@ final class CleanAuditLogsCommandTest extends TestCase
         self::assertStringContainsString('The command is already running in another process.', $output);
     }
 
+    public function testDateOption()
+    {
+        $command = $this->createCommand();
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            '--date' => '2023-04-26T09:00:00Z',
+        ]);
+        $command->unlock();
+
+        // the output of the command in the console
+        $output = $commandTester->getDisplay();
+        self::assertStringContainsString('clean audits created before 2023-04-26 09:00:00', $output);
+    }
+
+    public function testExcludeOption()
+    {
+        $command = $this->createCommand();
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            '--exclude' => 'DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Standard\Blog\Author',
+        ]);
+        $command->unlock();
+
+        // the output of the command in the console
+        $output = $commandTester->getDisplay();
+        self::assertStringContainsString('6 classes involved', $output);
+    }
+
+    public function testIncludeOption()
+    {
+        $command = $this->createCommand();
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            '--include' => 'DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Standard\Blog\Author',
+        ]);
+        $command->unlock();
+
+        // the output of the command in the console
+        $output = $commandTester->getDisplay();
+        self::assertStringContainsString('1 classes involved', $output);
+    }
+
     protected function createCommand(): CleanAuditLogsCommand
     {
         $command = new CleanAuditLogsCommand();


### PR DESCRIPTION
With this branch I adapted the cleanup command to be able to include or exclude specific entities and instead of using the keep argument there is a new option to specify a date instead.