### PR TITLE
Skip embedded class from schema listener

### DIFF
--- a/src/Provider/Doctrine/Persistence/Event/TableSchemaSubscriber.php
+++ b/src/Provider/Doctrine/Persistence/Event/TableSchemaSubscriber.php
@@ -22,7 +22,7 @@ class TableSchemaSubscriber implements EventSubscriber
     public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs): void
     {
         $classMetadata = $eventArgs->getClassMetadata();
-        if (!$classMetadata->isInheritanceTypeSingleTable() || $classMetadata->getName() === $classMetadata->rootEntityName) {
+        if (!$classMetadata->isEmbeddedClass && (!$classMetadata->isInheritanceTypeSingleTable() || $classMetadata->getName() === $classMetadata->rootEntityName)) {
             $schemaManager = new SchemaManager($this->provider);
             $storageService = $this->provider->getStorageServiceForEntity($classMetadata->getName());
 


### PR DESCRIPTION
This is an updated version of PR #183 from @guillaume-sainthillier
> When multiple storage is used, we can't handle embedded classes for a storage manager
