### PR TITLE
Useless `ext-json` requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
   ],
   "require": {
     "php": ">=8.2",
-    "ext-json": "*",
     "doctrine/dbal": "^2.13.1|^3.2",
     "doctrine/orm": "^2.13",
     "symfony/cache": "^5.4|^6.0|^7.0",


### PR DESCRIPTION
Remove useless `ext-json` requirement from `composer.json` 
@see https://php.watch/versions/8.0/ext-json