### PR TITLE
Small fixes to PlatformHelper.php

### DIFF
--- a/src/Provider/Doctrine/Persistence/Helper/PlatformHelper.php
+++ b/src/Provider/Doctrine/Persistence/Helper/PlatformHelper.php
@@ -104,11 +104,11 @@ abstract class PlatformHelper
     public static function getMariaDbMysqlVersionNumber(string $versionString): string
     {
         preg_match(
-            '#^(?:5\.5\.5-)?(mariadb-)?(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?#i',
+            '#^(?:5\.5\.5-)?(mariadb-)?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)#i',
             $versionString,
             $versionParts
         );
 
-        return $versionParts['major'].'.'.$versionParts['minor'].'.'.($versionParts['patch'] ?? '0');
+        return $versionParts['major'].'.'.$versionParts['minor'].'.'.$versionParts['patch'];
     }
 }

--- a/src/Provider/Doctrine/Persistence/Helper/PlatformHelper.php
+++ b/src/Provider/Doctrine/Persistence/Helper/PlatformHelper.php
@@ -104,11 +104,11 @@ abstract class PlatformHelper
     public static function getMariaDbMysqlVersionNumber(string $versionString): string
     {
         preg_match(
-            '#^(?:5\.5\.5-)?(mariadb-)?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)#i',
+            '#^(?:5\.5\.5-)?(mariadb-)?(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?#i',
             $versionString,
             $versionParts
         );
 
-        return $versionParts['major'].'.'.$versionParts['minor'].'.'.$versionParts['patch'];
+        return $versionParts['major'].'.'.$versionParts['minor'].'.'.($versionParts['patch'] ?? '0');
     }
 }

--- a/src/Provider/Doctrine/Persistence/Helper/PlatformHelper.php
+++ b/src/Provider/Doctrine/Persistence/Helper/PlatformHelper.php
@@ -46,7 +46,7 @@ abstract class PlatformHelper
             return $connection->getWrappedConnection()->getServerVersion();
         }
         if (method_exists($connection, 'getNativeConnection')) {
-            return $connection->getServerVersion();
+            return $connection->getNativeConnection()->getServerVersion();
         }
 
         return null;


### PR DESCRIPTION
- Conditional checks for existence of 'getNativeConnection' method, but then it doesn't call that method at all, and attempts to call directly `$connection->getServerVersion()`, which would fail because that method is private.
- ~~fix getMariaDbMysqlVersionNumber(), because sometimes $versionString may not have a patch version, in which case $versionParts will be `[]`.~~