### PR TITLE
Fix isJsonSupported for MariaDB

### DIFF
--- a/src/Provider/Doctrine/Persistence/Helper/PlatformHelper.php
+++ b/src/Provider/Doctrine/Persistence/Helper/PlatformHelper.php
@@ -76,7 +76,7 @@ abstract class PlatformHelper
                 return true;
             }
 
-            return version_compare(self::getMariaDbMysqlVersionNumber($version), '10.2.7', '<');
+            return version_compare(self::getMariaDbMysqlVersionNumber($version), '10.2.7', '>=');
         }
 
         return true;

--- a/tests/Provider/Doctrine/Persistence/Helper/PlatformHelperTest.php
+++ b/tests/Provider/Doctrine/Persistence/Helper/PlatformHelperTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Tests\Provider\Doctrine\Persistence\Helper;
+
+use DH\Auditor\Provider\Doctrine\Persistence\Helper\PlatformHelper;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[Small]
+final class PlatformHelperTest extends TestCase
+{
+    #[DataProvider('provideMariaDbVersionCases')]
+    public function testIsJsonSupportedForMariaDb(string $mariaDbVersion, bool $expectedResult): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDatabasePlatform')
+            ->willReturn(new MariaDbPlatform());
+        $connection->method('getServerVersion')
+            ->willReturn($mariaDbVersion);
+
+        $this->assertSame($expectedResult, PlatformHelper::isJsonSupported($connection));
+    }
+
+    /**
+     * @return iterable<string, array<string|bool>>
+     */
+    public static function provideMariaDbVersionCases(): iterable
+    {
+        yield '10.2.6' => ['10.2.6', false];
+        yield '10.2.7' => ['10.2.7', true];
+        yield '10.11.8-MariaDB-0ubuntu0.24.04.1' => ['10.11.8-MariaDB-0ubuntu0.24.04.1', true];
+    }
+}

--- a/tests/Provider/Doctrine/Persistence/Helper/PlatformHelperTest.php
+++ b/tests/Provider/Doctrine/Persistence/Helper/PlatformHelperTest.php
@@ -22,20 +22,24 @@ final class PlatformHelperTest extends TestCase
     {
         $connection = $this->createMock(Connection::class);
         $connection->method('getDatabasePlatform')
-            ->willReturn(new MariaDbPlatform());
+            ->willReturn(new MariaDBPlatform())
+        ;
         $connection->method('getServerVersion')
-            ->willReturn($mariaDbVersion);
+            ->willReturn($mariaDbVersion)
+        ;
 
         $this->assertSame($expectedResult, PlatformHelper::isJsonSupported($connection));
     }
 
     /**
-     * @return iterable<string, array<string|bool>>
+     * @return iterable<string, array<bool|string>>
      */
     public static function provideMariaDbVersionCases(): iterable
     {
         yield '10.2.6' => ['10.2.6', false];
+
         yield '10.2.7' => ['10.2.7', true];
+
         yield '10.11.8-MariaDB-0ubuntu0.24.04.1' => ['10.11.8-MariaDB-0ubuntu0.24.04.1', true];
     }
 }


### PR DESCRIPTION
The `version_compare()` operator argument seems weird, as it should return JSON is supported for MariaDB >= 10.2.7.  
Currently it returns the opposite.

Added tests to make sure it works correctly.