### PR TITLE
Strengthen type checking in AuditTrait

### DIFF
--- a/src/Provider/Doctrine/Auditing/Transaction/AuditTrait.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/AuditTrait.php
@@ -202,7 +202,10 @@ trait AuditTrait
             }
 
             if ($o !== $n) {
-                if (isset($type) && Type::getType(Types::JSON) === $type && (null === $o || is_array($o)) && (null === $n || is_array($n))) {
+                if (
+                    isset($type) && Type::getType(Types::JSON) === $type
+                    && (null === $o || \is_array($o)) && (null === $n || \is_array($n))
+                ) {
                     /**
                      * @var ?array $o
                      * @var ?array $n

--- a/src/Provider/Doctrine/Auditing/Transaction/AuditTrait.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/AuditTrait.php
@@ -202,7 +202,7 @@ trait AuditTrait
             }
 
             if ($o !== $n) {
-                if (isset($type) && Type::getType(Types::JSON) === $type) {
+                if (isset($type) && Type::getType(Types::JSON) === $type && (null === $o || is_array($o)) && (null === $n || is_array($n))) {
                     /**
                      * @var ?array $o
                      * @var ?array $n


### PR DESCRIPTION
Fixes #227

I'm between two minds whether (a) doing what I did is better than (b) tweaking `AuditTrait::deepDiff()` so that it can handle non-arrays. But then it's not a deep diff anymore, so changing the signature would justify changing the name. I went with (a) because it does the job, and the only other place where `deepDiff` is used already enforces the correct data type. 