### PR TITLE
[DRAFT] Add support for Storing audit logs in a single table

### DIFF
--- a/src/Provider/Doctrine/Persistence/Reader/Query.php
+++ b/src/Provider/Doctrine/Persistence/Reader/Query.php
@@ -67,10 +67,11 @@ final class Query
 
     private readonly \DateTimeZone $timezone;
 
-    public function __construct(private readonly string $table, private readonly Connection $connection, string $timezone)
+    public function __construct(private readonly string $table, private readonly Connection $connection, string $timezone, private ?array $supportedFilters = null)
     {
         $this->timezone = new \DateTimeZone($timezone);
 
+        $this->supportedFilters = ($supportedFilters ?? array_keys(SchemaHelper::getAuditTableIndices('fake')));
         foreach ($this->getSupportedFilters() as $filterType) {
             $this->filters[$filterType] = [];
         }
@@ -162,7 +163,7 @@ final class Query
 
     public function getSupportedFilters(): array
     {
-        return array_keys(SchemaHelper::getAuditTableIndices('fake'));
+        return $this->supportedFilters ?? [];
     }
 
     public function getFilters(): array

--- a/src/Provider/Doctrine/Persistence/Reader/Reader.php
+++ b/src/Provider/Doctrine/Persistence/Reader/Reader.php
@@ -45,10 +45,7 @@ final readonly class Reader
         $this->configureOptions($resolver);
         $config = $resolver->resolve($options);
 
-        $connection = $this->provider->getStorageServiceForEntity($entity)->getEntityManager()->getConnection();
-        $timezone = $this->provider->getAuditor()->getConfiguration()->getTimezone();
-
-        $query = new Query($this->getEntityAuditTableName($entity), $connection, $timezone);
+        $query = $this->provider->createBaseQuery($entity);
         $query
             ->addOrderBy(Query::CREATED_AT, 'DESC')
             ->addOrderBy(Query::ID, 'DESC')
@@ -159,24 +156,7 @@ final readonly class Reader
      */
     public function getEntityAuditTableName(string $entity): string
     {
-        /** @var Configuration $configuration */
-        $configuration = $this->provider->getConfiguration();
-
-        /** @var AuditingService $auditingService */
-        $auditingService = $this->provider->getAuditingServiceForEntity($entity);
-        $entityManager = $auditingService->getEntityManager();
-        $schema = '';
-        if ($entityManager->getClassMetadata($entity)->getSchemaName()) {
-            $schema = $entityManager->getClassMetadata($entity)->getSchemaName().'.';
-        }
-
-        return \sprintf(
-            '%s%s%s%s',
-            $schema,
-            $configuration->getTablePrefix(),
-            $this->getEntityTableName($entity),
-            $configuration->getTableSuffix()
-        );
+        return $this->provider->getEntityAuditTableName($entity);
     }
 
     private function configureOptions(OptionsResolver $resolver): void


### PR DESCRIPTION
The goal is to allow storing all audit logs in a single table instead of creating a separate table for each audited entity.

I am aware of the performance issues that this can cause on an application with a large volume https://github.com/DATA-DOG/DataDogAuditBundle/issues/32

This PR is a work in progress to validate the design and approach. 

I test the feature on the demo https://github.com/DamienHarper/auditor-bundle-demo by adding in `config/services.yaml` 

```
    app.doctrine_single_table:
        class: DH\Auditor\Provider\Doctrine\Service\SingleTableDoctrineService
        decorates: dh_auditor.provider.doctrine.storage_services.doctrine.orm.default_entity_manager
        arguments: ['@.inner', 'audit']

```

Work Remaining:

[ ] Add tests to cover the new feature.
[ ] Modify schema structures to support a single audit table.
[ ] Update the `Clean audit tables` and `Update audit tables` commands to support this feature.
[ ] Enable the feature via the bundle configuration
[ ] Update the audit table property of the event payload

