### PR TITLE
Fixed retrieving primary key for target entity

### DIFF
--- a/src/Provider/Doctrine/Auditing/Transaction/AuditTrait.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/AuditTrait.php
@@ -59,7 +59,7 @@ trait AuditTrait
         \assert(\is_object($type));
         \assert(\is_object($targetEntity));
 
-        return $this->value($entityManager, $type, DoctrineHelper::getReflectionPropertyValue($meta, $pk, $entity));
+        return $this->value($entityManager, $type, DoctrineHelper::getReflectionPropertyValue($meta, $pk, $targetEntity));
     }
 
     /**


### PR DESCRIPTION
This was changed by accident i assume from `$targetEntity` to `$entity`, when it should be `$targetEntity`: https://github.com/DamienHarper/auditor/commit/e49aace23d71cd333345a8d1ea21f01224bf96d3#diff-42979d7f080b503e72105bcb738209de2646bdd5d052e0cdaf3b2f9053b1f1e4R62