### PR TITLE
feat: add JsonFilter for querying extra_data JSON column

### DIFF
--- a/src/Provider/Doctrine/Persistence/Helper/JsonPlatformHelper.php
+++ b/src/Provider/Doctrine/Persistence/Helper/JsonPlatformHelper.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Provider\Doctrine\Persistence\Helper;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+
+/**
+ * Helper class for JSON-related SQL generation across different database platforms.
+ *
+ * Supports:
+ * - MySQL 5.7+
+ * - MariaDB 10.2.3+
+ * - PostgreSQL 9.4+
+ * - SQLite 3.38+
+ */
+abstract class JsonPlatformHelper
+{
+    /**
+     * Minimum versions required for JSON search support.
+     */
+    private const array MINIMUM_VERSIONS = [
+        'mysql' => '5.7.0',
+        'mariadb' => '10.2.3',
+        'postgresql' => '9.4.0',
+        'sqlite' => '3.38.0',
+    ];
+
+    /**
+     * Check if the database platform supports JSON search functions.
+     */
+    public static function isJsonSearchSupported(Connection $connection): bool
+    {
+        $platform = $connection->getDatabasePlatform();
+        $version = PlatformHelper::getServerVersion($connection);
+
+        if (null === $version) {
+            // Cannot determine version, assume supported for modern DBAL
+            return true;
+        }
+
+        if ($platform instanceof MariaDBPlatform) {
+            return version_compare(
+                PlatformHelper::getMariaDbMysqlVersionNumber($version),
+                self::MINIMUM_VERSIONS['mariadb'],
+                '>='
+            );
+        }
+
+        if ($platform instanceof MySQLPlatform) {
+            return version_compare(
+                PlatformHelper::getOracleMysqlVersionNumber($version),
+                self::MINIMUM_VERSIONS['mysql'],
+                '>='
+            );
+        }
+
+        if ($platform instanceof PostgreSQLPlatform) {
+            return version_compare(
+                self::getPostgreSQLVersionNumber($version),
+                self::MINIMUM_VERSIONS['postgresql'],
+                '>='
+            );
+        }
+
+        if ($platform instanceof SQLitePlatform) {
+            return version_compare(
+                self::getSQLiteVersionNumber($version),
+                self::MINIMUM_VERSIONS['sqlite'],
+                '>='
+            );
+        }
+
+        // Unknown platform, assume not supported
+        return false;
+    }
+
+    /**
+     * Build SQL expression to extract a JSON value at the given path.
+     *
+     * @param string $column The JSON column name (e.g., 'extra_data')
+     * @param string $path   The JSON path without $ prefix (e.g., 'department' or 'user.name')
+     *
+     * @return string SQL expression that extracts the value as text
+     */
+    public static function buildJsonExtractSql(Connection $connection, string $column, string $path): string
+    {
+        $platform = $connection->getDatabasePlatform();
+        $jsonPath = '$.'.$path;
+
+        if ($platform instanceof MariaDBPlatform) {
+            // MariaDB: JSON_UNQUOTE(JSON_EXTRACT(column, '$.path'))
+            return \sprintf("JSON_UNQUOTE(JSON_EXTRACT(%s, '%s'))", $column, $jsonPath);
+        }
+
+        if ($platform instanceof MySQLPlatform) {
+            // MySQL 5.7+: JSON_UNQUOTE(JSON_EXTRACT(column, '$.path'))
+            // MySQL 8.0+: column->>'$.path' is equivalent but we use the function for compatibility
+            return \sprintf("JSON_UNQUOTE(JSON_EXTRACT(%s, '%s'))", $column, $jsonPath);
+        }
+
+        if ($platform instanceof PostgreSQLPlatform) {
+            // PostgreSQL: column->>'path' for simple paths, or column #>> '{path,subpath}' for nested
+            if (!str_contains($path, '.')) {
+                return \sprintf("%s->>'%s'", $column, $path);
+            }
+
+            // Nested path: convert 'user.name' to '{user,name}'
+            $pathParts = explode('.', $path);
+            $pgPath = '{'.implode(',', $pathParts).'}';
+
+            return \sprintf("%s #>> '%s'", $column, $pgPath);
+        }
+
+        if ($platform instanceof SQLitePlatform) {
+            // SQLite 3.38+: json_extract(column, '$.path')
+            // Note: SQLite returns unquoted strings by default for json_extract
+            return \sprintf("json_extract(%s, '%s')", $column, $jsonPath);
+        }
+
+        // Fallback for unknown platforms - will likely fail but provides diagnostic info
+        return \sprintf("JSON_EXTRACT(%s, '%s')", $column, $jsonPath);
+    }
+
+    /**
+     * Build a fallback LIKE pattern for searching JSON content.
+     *
+     * @param string $path  The JSON path (e.g., 'department')
+     * @param mixed  $value The value to search for
+     *
+     * @return string LIKE pattern
+     */
+    public static function buildFallbackLikePattern(string $path, mixed $value): string
+    {
+        // Build pattern like: %"department":"value"% or %"department":value%
+        if (\is_string($value)) {
+            return \sprintf('%%"%s":"%s"%%', $path, $value);
+        }
+
+        if (\is_bool($value)) {
+            return \sprintf('%%"%s":%s%%', $path, $value ? 'true' : 'false');
+        }
+
+        if (null === $value) {
+            return \sprintf('%%"%s":null%%', $path);
+        }
+
+        // Numeric value
+        return \sprintf('%%"%s":%s%%', $path, (string) $value);
+    }
+
+    /**
+     * Get the minimum required versions for JSON search support.
+     *
+     * @return array<string, string>
+     */
+    public static function getMinimumVersions(): array
+    {
+        return self::MINIMUM_VERSIONS;
+    }
+
+    /**
+     * Get the platform name for error messages.
+     */
+    public static function getPlatformName(Connection $connection): string
+    {
+        $platform = $connection->getDatabasePlatform();
+
+        return match (true) {
+            $platform instanceof MariaDBPlatform => 'MariaDB',
+            $platform instanceof MySQLPlatform => 'MySQL',
+            $platform instanceof PostgreSQLPlatform => 'PostgreSQL',
+            $platform instanceof SQLitePlatform => 'SQLite',
+            default => $platform::class,
+        };
+    }
+
+    /**
+     * Extract PostgreSQL version number.
+     */
+    private static function getPostgreSQLVersionNumber(string $versionString): string
+    {
+        // PostgreSQL version strings are typically like "15.2" or "PostgreSQL 15.2 on ..."
+        if (preg_match('#(\d+)\.(\d+)(?:\.(\d+))?#', $versionString, $matches)) {
+            return $matches[1].'.'.$matches[2].'.'.($matches[3] ?? '0');
+        }
+
+        return '0.0.0';
+    }
+
+    /**
+     * Extract SQLite version number.
+     */
+    private static function getSQLiteVersionNumber(string $versionString): string
+    {
+        // SQLite version strings are typically like "3.38.5"
+        if (preg_match('#(\d+)\.(\d+)\.(\d+)#', $versionString, $matches)) {
+            return $matches[1].'.'.$matches[2].'.'.$matches[3];
+        }
+
+        return '0.0.0';
+    }
+}

--- a/src/Provider/Doctrine/Persistence/Reader/Filter/JsonFilter.php
+++ b/src/Provider/Doctrine/Persistence/Reader/Filter/JsonFilter.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter;
+
+use DH\Auditor\Exception\InvalidArgumentException;
+use DH\Auditor\Provider\Doctrine\Persistence\Helper\JsonPlatformHelper;
+use Doctrine\DBAL\Connection;
+
+/**
+ * Filter for querying JSON column content.
+ *
+ * Supports extraction of scalar values from JSON columns with platform-specific SQL generation.
+ * When the database doesn't support JSON functions, falls back to LIKE pattern matching
+ * (unless strict mode is enabled).
+ *
+ * Supported operators: =, !=, <>, LIKE, NOT LIKE, IN, NOT IN, IS NULL, IS NOT NULL
+ *
+ * @example
+ * // Filter by exact value
+ * new JsonFilter('extra_data', 'department', 'IT')
+ *
+ * // Filter with LIKE
+ * new JsonFilter('extra_data', 'department', 'IT%', 'LIKE')
+ *
+ * // Filter with IN
+ * new JsonFilter('extra_data', 'status', ['active', 'pending'], 'IN')
+ *
+ * // Strict mode - throws exception if JSON not supported
+ * new JsonFilter('extra_data', 'department', 'IT', '=', true)
+ *
+ * @note Only scalar value extraction is supported in this version.
+ *       Nested arrays/objects comparison (e.g., JSON_CONTAINS) is not yet implemented.
+ */
+final readonly class JsonFilter implements PlatformAwareFilterInterface
+{
+    private const array VALID_OPERATORS = ['=', '!=', '<>', 'LIKE', 'NOT LIKE', 'IN', 'NOT IN', 'IS NULL', 'IS NOT NULL'];
+
+    private const array NULL_OPERATORS = ['IS NULL', 'IS NOT NULL'];
+
+    /**
+     * @param string $column   The JSON column name (e.g., 'extra_data')
+     * @param string $path     The JSON path to extract (e.g., 'department' or 'user.role')
+     * @param mixed  $value    The value to compare against (ignored for IS NULL/IS NOT NULL)
+     * @param string $operator The comparison operator
+     * @param bool   $strict   If true, throws exception when JSON is not supported instead of falling back to LIKE
+     *
+     * @throws InvalidArgumentException If operator is not valid or if value is invalid for the operator
+     */
+    public function __construct(
+        private string $column,
+        private string $path,
+        private mixed $value = null,
+        private string $operator = '=',
+        private bool $strict = false,
+    ) {
+        $normalizedOperator = mb_strtoupper(mb_trim($this->operator));
+
+        if (!\in_array($normalizedOperator, self::VALID_OPERATORS, true)) {
+            throw new InvalidArgumentException(\sprintf(
+                'Invalid operator "%s". Allowed operators: %s',
+                $this->operator,
+                implode(', ', self::VALID_OPERATORS)
+            ));
+        }
+
+        if (\in_array($normalizedOperator, ['IN', 'NOT IN'], true) && !\is_array($this->value)) {
+            throw new InvalidArgumentException(\sprintf(
+                'Operator "%s" requires an array value.',
+                $this->operator
+            ));
+        }
+
+        if (!\in_array($normalizedOperator, self::NULL_OPERATORS, true) && !\in_array($normalizedOperator, ['IN', 'NOT IN'], true) && \is_array($this->value)) {
+            throw new InvalidArgumentException(\sprintf(
+                'Operator "%s" does not accept array values. Use IN or NOT IN instead.',
+                $this->operator
+            ));
+        }
+    }
+
+    public function getName(): string
+    {
+        return 'json';
+    }
+
+    /**
+     * @throws InvalidArgumentException Always throws as this filter requires a connection
+     */
+    #[\Deprecated(message: 'Use getSQLWithConnection() instead')]
+    public function getSQL(): array
+    {
+        throw new InvalidArgumentException(
+            'JsonFilter requires a database connection. Use getSQLWithConnection() instead.'
+        );
+    }
+
+    public function getSQLWithConnection(Connection $connection): array
+    {
+        $normalizedOperator = mb_strtoupper(mb_trim($this->operator));
+
+        // Check JSON support
+        if (!JsonPlatformHelper::isJsonSearchSupported($connection)) {
+            return $this->handleUnsupportedJson($connection, $normalizedOperator);
+        }
+
+        return $this->buildJsonSql($connection, $normalizedOperator);
+    }
+
+    /**
+     * Build SQL using native JSON functions.
+     *
+     * @return array{sql: string, params: array<string, mixed>}
+     */
+    private function buildJsonSql(Connection $connection, string $operator): array
+    {
+        $jsonExtract = JsonPlatformHelper::buildJsonExtractSql($connection, $this->column, $this->path);
+        $paramName = 'json_'.preg_replace('/[^a-zA-Z0-9_]/', '_', $this->path);
+
+        // Handle NULL operators
+        if ('IS NULL' === $operator) {
+            return [
+                'sql' => \sprintf('(%s IS NULL OR %s IS NULL)', $this->column, $jsonExtract),
+                'params' => [],
+            ];
+        }
+
+        if ('IS NOT NULL' === $operator) {
+            return [
+                'sql' => \sprintf('(%s IS NOT NULL AND %s IS NOT NULL)', $this->column, $jsonExtract),
+                'params' => [],
+            ];
+        }
+
+        // Handle IN/NOT IN operators
+        if (\in_array($operator, ['IN', 'NOT IN'], true)) {
+            return [
+                'sql' => \sprintf('%s %s (:%s)', $jsonExtract, $operator, $paramName),
+                'params' => [$paramName => $this->value],
+            ];
+        }
+
+        // Handle standard operators
+        return [
+            'sql' => \sprintf('%s %s :%s', $jsonExtract, $operator, $paramName),
+            'params' => [$paramName => $this->value],
+        ];
+    }
+
+    /**
+     * Handle case when JSON is not supported by the database.
+     *
+     * @return array{sql: string, params: array<string, mixed>}
+     *
+     * @throws InvalidArgumentException If strict mode is enabled
+     */
+    private function handleUnsupportedJson(Connection $connection, string $operator): array
+    {
+        $platformName = JsonPlatformHelper::getPlatformName($connection);
+        $minVersions = JsonPlatformHelper::getMinimumVersions();
+
+        $message = \sprintf(
+            'JSON search is not supported on this %s version. Minimum required versions: MySQL %s, MariaDB %s, PostgreSQL %s, SQLite %s.',
+            $platformName,
+            $minVersions['mysql'],
+            $minVersions['mariadb'],
+            $minVersions['postgresql'],
+            $minVersions['sqlite']
+        );
+
+        if ($this->strict) {
+            throw new InvalidArgumentException($message.' Strict mode is enabled, fallback to LIKE is disabled.');
+        }
+
+        // Trigger warning
+        trigger_error(
+            $message.' Falling back to LIKE pattern matching which may produce inaccurate results.',
+            E_USER_WARNING
+        );
+
+        return $this->buildFallbackLikeSql($operator);
+    }
+
+    /**
+     * Build fallback SQL using LIKE pattern matching.
+     *
+     * @return array{sql: string, params: array<string, mixed>}
+     */
+    private function buildFallbackLikeSql(string $operator): array
+    {
+        $paramName = 'json_like_'.preg_replace('/[^a-zA-Z0-9_]/', '_', $this->path);
+
+        // Handle NULL operators
+        if ('IS NULL' === $operator) {
+            // Check if column is NULL or doesn't contain the path
+            return [
+                'sql' => \sprintf("(%s IS NULL OR %s NOT LIKE '%%\"%s\":%%')", $this->column, $this->column, $this->path),
+                'params' => [],
+            ];
+        }
+
+        if ('IS NOT NULL' === $operator) {
+            return [
+                'sql' => \sprintf("(%s IS NOT NULL AND %s LIKE '%%\"%s\":%%')", $this->column, $this->column, $this->path),
+                'params' => [],
+            ];
+        }
+
+        // Handle IN operator - combine multiple LIKE patterns with OR
+        if ('IN' === $operator) {
+            $conditions = [];
+            $params = [];
+            foreach ($this->value as $i => $val) {
+                $pName = $paramName.'_'.$i;
+                $conditions[] = \sprintf('%s LIKE :%s', $this->column, $pName);
+                $params[$pName] = JsonPlatformHelper::buildFallbackLikePattern($this->path, $val);
+            }
+
+            return [
+                'sql' => '('.implode(' OR ', $conditions).')',
+                'params' => $params,
+            ];
+        }
+
+        // Handle NOT IN operator
+        if ('NOT IN' === $operator) {
+            $conditions = [];
+            $params = [];
+            foreach ($this->value as $i => $val) {
+                $pName = $paramName.'_'.$i;
+                $conditions[] = \sprintf('%s NOT LIKE :%s', $this->column, $pName);
+                $params[$pName] = JsonPlatformHelper::buildFallbackLikePattern($this->path, $val);
+            }
+
+            return [
+                'sql' => '('.implode(' AND ', $conditions).')',
+                'params' => $params,
+            ];
+        }
+
+        // Handle != and <> operators
+        if (\in_array($operator, ['!=', '<>'], true)) {
+            $pattern = JsonPlatformHelper::buildFallbackLikePattern($this->path, $this->value);
+
+            return [
+                'sql' => \sprintf('%s NOT LIKE :%s', $this->column, $paramName),
+                'params' => [$paramName => $pattern],
+            ];
+        }
+
+        // Handle LIKE operator - user provides their own pattern
+        if ('LIKE' === $operator) {
+            // For LIKE, we search the raw value in the column
+            return [
+                'sql' => \sprintf('%s LIKE :%s', $this->column, $paramName),
+                'params' => [$paramName => '%'.$this->value.'%'],
+            ];
+        }
+
+        // Handle NOT LIKE operator
+        if ('NOT LIKE' === $operator) {
+            return [
+                'sql' => \sprintf('%s NOT LIKE :%s', $this->column, $paramName),
+                'params' => [$paramName => '%'.$this->value.'%'],
+            ];
+        }
+
+        // Default: = operator
+        $pattern = JsonPlatformHelper::buildFallbackLikePattern($this->path, $this->value);
+
+        return [
+            'sql' => \sprintf('%s LIKE :%s', $this->column, $paramName),
+            'params' => [$paramName => $pattern],
+        ];
+    }
+}

--- a/src/Provider/Doctrine/Persistence/Reader/Filter/PlatformAwareFilterInterface.php
+++ b/src/Provider/Doctrine/Persistence/Reader/Filter/PlatformAwareFilterInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Interface for filters that require database platform detection.
+ *
+ * Filters implementing this interface receive the database connection
+ * to generate platform-specific SQL (e.g., JSON functions).
+ */
+interface PlatformAwareFilterInterface extends FilterInterface
+{
+    /**
+     * Returns SQL and parameters for this filter, using platform-specific syntax.
+     *
+     * @return array{sql: string, params: array<string, mixed>}
+     */
+    public function getSQLWithConnection(Connection $connection): array;
+}

--- a/tests/Provider/Doctrine/Persistence/Helper/JsonPlatformHelperTest.php
+++ b/tests/Provider/Doctrine/Persistence/Helper/JsonPlatformHelperTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Tests\Provider\Doctrine\Persistence\Helper;
+
+use DH\Auditor\Provider\Doctrine\Persistence\Helper\JsonPlatformHelper;
+use DH\Auditor\Tests\Provider\Doctrine\Traits\ConnectionTrait;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[Small]
+final class JsonPlatformHelperTest extends TestCase
+{
+    use ConnectionTrait;
+
+    public function testGetMinimumVersions(): void
+    {
+        $versions = JsonPlatformHelper::getMinimumVersions();
+
+        $this->assertArrayHasKey('mysql', $versions);
+        $this->assertArrayHasKey('mariadb', $versions);
+        $this->assertArrayHasKey('postgresql', $versions);
+        $this->assertArrayHasKey('sqlite', $versions);
+
+        $this->assertSame('5.7.0', $versions['mysql']);
+        $this->assertSame('10.2.3', $versions['mariadb']);
+        $this->assertSame('9.4.0', $versions['postgresql']);
+        $this->assertSame('3.38.0', $versions['sqlite']);
+    }
+
+    public function testIsJsonSearchSupportedWithCurrentConnection(): void
+    {
+        $connection = $this->createConnection();
+
+        // Should return a boolean (the actual value depends on the database being used)
+        $result = JsonPlatformHelper::isJsonSearchSupported($connection);
+
+        $this->assertIsBool($result);
+    }
+
+    public function testBuildJsonExtractSqlWithCurrentConnection(): void
+    {
+        $connection = $this->createConnection();
+        $platform = $connection->getDatabasePlatform();
+
+        $sql = JsonPlatformHelper::buildJsonExtractSql($connection, 'extra_data', 'department');
+
+        // Verify that SQL is generated and contains expected elements
+        $this->assertNotEmpty($sql);
+        $this->assertStringContainsString('extra_data', $sql);
+
+        // Platform-specific assertions
+        if ($platform instanceof SQLitePlatform) {
+            $this->assertStringContainsString('json_extract', $sql);
+            $this->assertStringContainsString('$.department', $sql);
+        } elseif ($platform instanceof MySQLPlatform || $platform instanceof MariaDBPlatform) {
+            $this->assertStringContainsString('JSON_EXTRACT', $sql);
+            $this->assertStringContainsString('JSON_UNQUOTE', $sql);
+            $this->assertStringContainsString('$.department', $sql);
+        } elseif ($platform instanceof PostgreSQLPlatform) {
+            $this->assertStringContainsString("->>'department'", $sql);
+        }
+    }
+
+    public function testBuildJsonExtractSqlNestedPath(): void
+    {
+        $connection = $this->createConnection();
+        $platform = $connection->getDatabasePlatform();
+
+        $sql = JsonPlatformHelper::buildJsonExtractSql($connection, 'extra_data', 'user.role');
+
+        $this->assertNotEmpty($sql);
+        $this->assertStringContainsString('extra_data', $sql);
+
+        // Platform-specific assertions for nested paths
+        if ($platform instanceof SQLitePlatform) {
+            $this->assertStringContainsString('$.user.role', $sql);
+        } elseif ($platform instanceof MySQLPlatform || $platform instanceof MariaDBPlatform) {
+            $this->assertStringContainsString('$.user.role', $sql);
+        } elseif ($platform instanceof PostgreSQLPlatform) {
+            $this->assertStringContainsString('{user,role}', $sql);
+        }
+    }
+
+    public function testGetPlatformName(): void
+    {
+        $connection = $this->createConnection();
+
+        $name = JsonPlatformHelper::getPlatformName($connection);
+
+        $this->assertNotEmpty($name);
+        $this->assertContains($name, ['MySQL', 'MariaDB', 'PostgreSQL', 'SQLite']);
+    }
+
+    public function testBuildFallbackLikePatternString(): void
+    {
+        $pattern = JsonPlatformHelper::buildFallbackLikePattern('department', 'IT');
+
+        $this->assertSame('%"department":"IT"%', $pattern);
+    }
+
+    public function testBuildFallbackLikePatternNumeric(): void
+    {
+        $pattern = JsonPlatformHelper::buildFallbackLikePattern('count', 42);
+
+        $this->assertSame('%"count":42%', $pattern);
+    }
+
+    public function testBuildFallbackLikePatternBoolean(): void
+    {
+        $patternTrue = JsonPlatformHelper::buildFallbackLikePattern('active', true);
+        $patternFalse = JsonPlatformHelper::buildFallbackLikePattern('active', false);
+
+        $this->assertSame('%"active":true%', $patternTrue);
+        $this->assertSame('%"active":false%', $patternFalse);
+    }
+
+    public function testBuildFallbackLikePatternNull(): void
+    {
+        $pattern = JsonPlatformHelper::buildFallbackLikePattern('deleted_at', null);
+
+        $this->assertSame('%"deleted_at":null%', $pattern);
+    }
+}

--- a/tests/Provider/Doctrine/Persistence/Reader/Filter/JsonFilterTest.php
+++ b/tests/Provider/Doctrine/Persistence/Reader/Filter/JsonFilterTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Tests\Provider\Doctrine\Persistence\Reader\Filter;
+
+use DH\Auditor\Exception\InvalidArgumentException;
+use DH\Auditor\Provider\Doctrine\Persistence\Reader\Filter\JsonFilter;
+use DH\Auditor\Provider\Doctrine\Persistence\Reader\Query;
+use DH\Auditor\Tests\Provider\Doctrine\Traits\ConnectionTrait;
+use DH\Auditor\Tests\Traits\ReflectionTrait;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[Small]
+final class JsonFilterTest extends TestCase
+{
+    use ConnectionTrait;
+    use ReflectionTrait;
+
+    public function testGetName(): void
+    {
+        $filter = new JsonFilter('extra_data', 'department', 'IT');
+
+        $this->assertSame('json', $filter->getName());
+    }
+
+    public function testInvalidOperator(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid operator');
+
+        new JsonFilter('extra_data', 'department', 'IT', 'INVALID');
+    }
+
+    public function testInOperatorRequiresArray(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('requires an array value');
+
+        new JsonFilter('extra_data', 'department', 'IT', 'IN');
+    }
+
+    public function testNotInOperatorRequiresArray(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('requires an array value');
+
+        new JsonFilter('extra_data', 'department', 'IT', 'NOT IN');
+    }
+
+    public function testEqualsOperatorRejectsArray(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('does not accept array values');
+
+        new JsonFilter('extra_data', 'department', ['IT', 'HR'], '=');
+    }
+
+    #[IgnoreDeprecations]
+    public function testGetSQLThrowsException(): void
+    {
+        $filter = new JsonFilter('extra_data', 'department', 'IT');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('requires a database connection');
+
+        $filter->getSQL();
+    }
+
+    public function testGetSQLWithConnectionEquals(): void
+    {
+        $connection = $this->createConnection();
+        $filter = new JsonFilter('extra_data', 'department', 'IT');
+
+        $result = $filter->getSQLWithConnection($connection);
+
+        $this->assertArrayHasKey('sql', $result);
+        $this->assertArrayHasKey('params', $result);
+        $this->assertArrayHasKey('json_department', $result['params']);
+        $this->assertSame('IT', $result['params']['json_department']);
+    }
+
+    public function testGetSQLWithConnectionNotEquals(): void
+    {
+        $connection = $this->createConnection();
+        $filter = new JsonFilter('extra_data', 'department', 'IT', '!=');
+
+        $result = $filter->getSQLWithConnection($connection);
+
+        $this->assertArrayHasKey('sql', $result);
+        $this->assertStringContainsString('!=', $result['sql']);
+    }
+
+    public function testGetSQLWithConnectionLike(): void
+    {
+        $connection = $this->createConnection();
+        $filter = new JsonFilter('extra_data', 'department', 'IT%', 'LIKE');
+
+        $result = $filter->getSQLWithConnection($connection);
+
+        $this->assertArrayHasKey('sql', $result);
+        $this->assertStringContainsString('LIKE', $result['sql']);
+    }
+
+    public function testGetSQLWithConnectionIn(): void
+    {
+        $connection = $this->createConnection();
+        $filter = new JsonFilter('extra_data', 'department', ['IT', 'HR', 'Finance'], 'IN');
+
+        $result = $filter->getSQLWithConnection($connection);
+
+        $this->assertArrayHasKey('sql', $result);
+        $this->assertStringContainsString('IN', $result['sql']);
+        $this->assertSame(['IT', 'HR', 'Finance'], $result['params']['json_department']);
+    }
+
+    public function testGetSQLWithConnectionNotIn(): void
+    {
+        $connection = $this->createConnection();
+        $filter = new JsonFilter('extra_data', 'department', ['IT', 'HR'], 'NOT IN');
+
+        $result = $filter->getSQLWithConnection($connection);
+
+        $this->assertArrayHasKey('sql', $result);
+        $this->assertStringContainsString('NOT IN', $result['sql']);
+    }
+
+    public function testGetSQLWithConnectionIsNull(): void
+    {
+        $connection = $this->createConnection();
+        $filter = new JsonFilter('extra_data', 'department', null, 'IS NULL');
+
+        $result = $filter->getSQLWithConnection($connection);
+
+        $this->assertArrayHasKey('sql', $result);
+        $this->assertStringContainsString('IS NULL', $result['sql']);
+        $this->assertSame([], $result['params']);
+    }
+
+    public function testGetSQLWithConnectionIsNotNull(): void
+    {
+        $connection = $this->createConnection();
+        $filter = new JsonFilter('extra_data', 'department', null, 'IS NOT NULL');
+
+        $result = $filter->getSQLWithConnection($connection);
+
+        $this->assertArrayHasKey('sql', $result);
+        $this->assertStringContainsString('IS NOT NULL', $result['sql']);
+        $this->assertSame([], $result['params']);
+    }
+
+    public function testNestedJsonPath(): void
+    {
+        $connection = $this->createConnection();
+        $filter = new JsonFilter('extra_data', 'user.role', 'admin');
+
+        $result = $filter->getSQLWithConnection($connection);
+
+        $this->assertArrayHasKey('sql', $result);
+        $this->assertArrayHasKey('params', $result);
+        // The param name should be sanitized (dots replaced with underscores)
+        $this->assertArrayHasKey('json_user_role', $result['params']);
+    }
+
+    #[Depends('testGetSQLWithConnectionEquals')]
+    public function testQueryIntegrationWithJsonFilter(): void
+    {
+        $connection = $this->createConnection();
+        $query = new Query('test_audit', $connection, 'UTC');
+        $filter = new JsonFilter('extra_data', 'department', 'IT');
+
+        $query->addFilter($filter);
+
+        $filters = $query->getFilters();
+        $this->assertCount(1, $filters[Query::JSON]);
+        $this->assertSame($filter, $filters[Query::JSON][0]);
+    }
+
+    #[Depends('testQueryIntegrationWithJsonFilter')]
+    public function testBuildQueryBuilderWithJsonFilter(): void
+    {
+        $connection = $this->createConnection();
+        $query = new Query('test_audit', $connection, 'UTC');
+        $filter = new JsonFilter('extra_data', 'department', 'IT');
+
+        $query->addFilter($filter);
+
+        $reflectedMethod = $this->reflectMethod($query, 'buildQueryBuilder');
+        $queryBuilder = $reflectedMethod->invokeArgs($query, []);
+
+        $sql = $queryBuilder->getSQL();
+        $params = $queryBuilder->getParameters();
+
+        // Should contain the JSON extraction and comparison
+        $this->assertStringContainsString('extra_data', (string) $sql);
+        $this->assertStringContainsString('department', (string) $sql);
+        $this->assertArrayHasKey('json_department', $params);
+        $this->assertSame('IT', $params['json_department']);
+    }
+}


### PR DESCRIPTION
This pull request introduces comprehensive support for filtering audit entries by JSON column content (such as `extra_data`) across multiple database platforms. It adds a new `JsonFilter` class, updates the documentation to reflect its usage and limitations, and implements a helper for generating platform-specific SQL for JSON extraction. The changes are focused on enhancing query capabilities, improving documentation, and ensuring cross-database compatibility.

**New filtering capabilities:**

- Added the `JsonFilter` class, enabling filtering of audit entries by values within JSON columns (e.g., `extra_data`), with support for a variety of operators (`=`, `!=`, `LIKE`, `IN`, `IS NULL`, etc.), and nested JSON paths using dot notation. [[1]](diffhunk://#diff-94ad9f1d6d52e2250fd771ca1092087d618e7d6999e257df3cd9752f71a18023R15) [[2]](diffhunk://#diff-94ad9f1d6d52e2250fd771ca1092087d618e7d6999e257df3cd9752f71a18023R416-R536)

**Platform compatibility and SQL generation:**

- Introduced `JsonPlatformHelper` (`src/Provider/Doctrine/Persistence/Helper/JsonPlatformHelper.php`), which detects database platform/version and generates the appropriate SQL for extracting JSON values, with fallbacks and strict mode for unsupported platforms.

**Documentation improvements:**

- Expanded documentation in `docs/extra-data.md` to include detailed usage examples, supported operators, supported databases and versions, strict mode, limitations, and recommendations for JSON indexing for performance.
- Updated `docs/querying/filters.md` to document the new `JsonFilter`, its constructor, supported operators, example usage, and generated SQL for each supported database. [[1]](diffhunk://#diff-94ad9f1d6d52e2250fd771ca1092087d618e7d6999e257df3cd9752f71a18023R15) [[2]](diffhunk://#diff-94ad9f1d6d52e2250fd771ca1092087d618e7d6999e257df3cd9752f71a18023R416-R536)

**Limitations and caveats:**

- Clearly documented that only scalar value extraction is supported (array/object comparisons like `JSON_CONTAINS` are not yet implemented), and that the fallback to `LIKE` pattern matching may yield inaccurate results. [[1]](diffhunk://#diff-275ba24b8caa6b2d6d7f2320af875b378b730551b8dbc41961874ca235467ea6L204-R333) [[2]](diffhunk://#diff-94ad9f1d6d52e2250fd771ca1092087d618e7d6999e257df3cd9752f71a18023R416-R536)

**Indexing recommendations:**

- Provided SQL examples for adding functional or GIN indexes on JSON paths for MySQL, MariaDB, PostgreSQL, and notes on limitations for SQLite to improve query performance.