### PR TITLE
feat(Query): add resetQueryPart() method to reset specific query parts

### DIFF
--- a/docs/querying/index.md
+++ b/docs/querying/index.md
@@ -148,6 +148,32 @@ $query->limit(100, 0);  // limit, offset
 $audits = $query->execute();
 ```
 
+### Resetting Query Parts
+
+You can reset specific parts of a query using `resetQueryPart()`:
+
+```php
+$query = $reader->createQuery(User::class);
+
+// Reset order by clauses
+$query->resetQueryPart('orderBy');
+
+// Reset limit and offset
+$query->resetQueryPart('limit');
+
+// Reset all filters
+$query->resetQueryPart('filters');
+```
+
+| Part      | Description                                  |
+|-----------|----------------------------------------------|
+| `orderBy` | Resets all ORDER BY clauses                  |
+| `limit`   | Resets LIMIT and OFFSET to 0                 |
+| `filters` | Resets all filters to empty arrays           |
+
+> [!TIP]
+> You can also use the shorthand `resetOrderBy()` method which is equivalent to `resetQueryPart('orderBy')`.
+
 ### Query Constants
 
 ```php

--- a/src/Provider/Doctrine/Persistence/Reader/Query.php
+++ b/src/Provider/Doctrine/Persistence/Reader/Query.php
@@ -121,7 +121,22 @@ final class Query implements QueryInterface
 
     public function resetOrderBy(): self
     {
-        $this->orderBy = [];
+        return $this->resetQueryPart('orderBy');
+    }
+
+    public function resetQueryPart(string $part): self
+    {
+        $allowedParts = ['orderBy', 'limit', 'filters'];
+
+        if (!\in_array($part, $allowedParts, true)) {
+            throw new InvalidArgumentException(\sprintf('Invalid query part "%s", allowed parts: %s.', $part, implode(', ', $allowedParts)));
+        }
+
+        match ($part) {
+            'orderBy' => $this->orderBy = [],
+            'limit' => [$this->limit, $this->offset] = [0, 0],
+            'filters' => $this->filters = array_fill_keys($this->getSupportedFilters(), []),
+        };
 
         return $this;
     }


### PR DESCRIPTION
This pull request introduces a new method to the `Query` class that allows resetting specific query parts (`orderBy`, `limit`, or `filters`) in a more flexible way. It also adds comprehensive tests to ensure this functionality works correctly and handles invalid input gracefully.

Enhancements to query part resetting:

* Added a new `resetQueryPart` method to the `Query` class in `src/Provider/Doctrine/Persistence/Reader/Query.php`, allowing selective reset of `orderBy`, `limit`, or `filters` and throwing an exception for invalid parts. The `resetOrderBy` method now delegates to this new method.

Testing improvements:

* Added new tests in `tests/Provider/Doctrine/Persistence/Reader/QueryTest.php` to verify `resetQueryPart` correctly resets `orderBy`, `limit`, and `filters`, and to check that an exception is thrown for invalid query parts.