### PR TITLE
Continuous schema updates triggered with PostgreSQL 16

### DIFF
--- a/src/Provider/Doctrine/Persistence/Helper/PlatformHelper.php
+++ b/src/Provider/Doctrine/Persistence/Helper/PlatformHelper.php
@@ -16,6 +16,27 @@ abstract class PlatformHelper
      *
      * @see https://github.com/doctrine/dbal/issues/3419
      */
+    /**
+     * Returns column-level platform options (e.g. charset/collation) that should be applied
+     * to STRING columns in audit tables.
+     *
+     * PostgreSQL does not use per-column charset/collation, so passing defaultTableOptions
+     * as platformOptions on PostgreSQL columns causes the schema comparator to detect false
+     * differences (the introspected column has no platformOptions, but the new definition
+     * would have them). We therefore only propagate defaultTableOptions on MySQL/MariaDB.
+     *
+     * @see https://github.com/DamienHarper/auditor/issues/241
+     */
+    public static function getColumnPlatformOptions(Connection $connection): array
+    {
+        $platform = $connection->getDatabasePlatform();
+        if ($platform instanceof MySQLPlatform || $platform instanceof MariaDBPlatform) {
+            return $connection->getParams()['defaultTableOptions'] ?? [];
+        }
+
+        return [];
+    }
+
     public static function isIndexLengthLimited(string $name, Connection $connection): bool
     {
         $columns = SchemaHelper::getAuditTableColumns();

--- a/src/Provider/Doctrine/Persistence/Schema/SchemaManager.php
+++ b/src/Provider/Doctrine/Persistence/Schema/SchemaManager.php
@@ -174,7 +174,7 @@ final readonly class SchemaManager
 
             // Add columns to audit table
             $isJsonSupported = PlatformHelper::isJsonSupported($connection);
-            foreach (SchemaHelper::getAuditTableColumns($connection->getParams()['defaultTableOptions'] ?? []) as $columnName => $struct) {
+            foreach (SchemaHelper::getAuditTableColumns(PlatformHelper::getColumnPlatformOptions($connection)) as $columnName => $struct) {
                 if (\in_array($struct['type'], DoctrineHelper::jsonStringTypes(), true)) {
                     $type = $isJsonSupported ? Types::JSON : Types::TEXT;
                 } else {
@@ -230,7 +230,7 @@ final readonly class SchemaManager
         $table = $schema->getTable($auditTablename);
 
         // process columns
-        $this->processColumns($table, $table->getColumns(), SchemaHelper::getAuditTableColumns($connection->getParams()['defaultTableOptions'] ?? []), $connection);
+        $this->processColumns($table, $table->getColumns(), SchemaHelper::getAuditTableColumns(PlatformHelper::getColumnPlatformOptions($connection)), $connection);
 
         // process indices
         $this->processIndices($table, SchemaHelper::getAuditTableIndices($auditTablename), $connection);

--- a/tests/Provider/Doctrine/Persistence/Helper/PlatformHelperTest.php
+++ b/tests/Provider/Doctrine/Persistence/Helper/PlatformHelperTest.php
@@ -7,6 +7,8 @@ namespace DH\Auditor\Tests\Provider\Doctrine\Persistence\Helper;
 use DH\Auditor\Provider\Doctrine\Persistence\Helper\PlatformHelper;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Small;
@@ -43,5 +45,57 @@ final class PlatformHelperTest extends TestCase
         yield ['10.2.7', true];
 
         yield ['10.11.8-MariaDB-0ubuntu0.24.04.1', true];
+    }
+
+    /**
+     * Ensures that defaultTableOptions are propagated as column platform options only on
+     * MySQL/MariaDB platforms. PostgreSQL does not support per-column charset/collation,
+     * so passing them causes the schema comparator to generate false-positive migrations.
+     *
+     * @see https://github.com/DamienHarper/auditor/issues/241
+     */
+    #[DataProvider('provideGetColumnPlatformOptionsCases')]
+    public function testGetColumnPlatformOptions(object $platform, array $params, array $expected): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDatabasePlatform')->willReturn($platform);
+        $connection->method('getParams')->willReturn($params);
+
+        $this->assertSame($expected, PlatformHelper::getColumnPlatformOptions($connection));
+    }
+
+    /**
+     * @return iterable<string, array{object, array<string, mixed>, array<string, string>}>
+     */
+    public static function provideGetColumnPlatformOptionsCases(): iterable
+    {
+        $mysqlOptions = ['charset' => 'utf8mb4', 'collation' => 'utf8mb4_unicode_ci'];
+        $pgOptions = ['charset' => 'UTF8', 'collate' => 'UTF8'];
+
+        yield 'MySQL returns defaultTableOptions' => [
+            new MySQLPlatform(),
+            ['defaultTableOptions' => $mysqlOptions],
+            $mysqlOptions,
+        ];
+
+        yield 'MariaDB returns defaultTableOptions' => [
+            new MariaDBPlatform(),
+            ['defaultTableOptions' => $mysqlOptions],
+            $mysqlOptions,
+        ];
+
+        // Regression test for issue #241: PostgreSQL must return [] so that the schema
+        // comparator does not see per-column charset/collation as a difference.
+        yield 'PostgreSQL returns empty array even when defaultTableOptions are set' => [
+            new PostgreSQLPlatform(),
+            ['defaultTableOptions' => $pgOptions],
+            [],
+        ];
+
+        yield 'MySQL returns empty array when no defaultTableOptions' => [
+            new MySQLPlatform(),
+            [],
+            [],
+        ];
     }
 }


### PR DESCRIPTION
This pull request addresses an issue where per-column charset and collation options from `defaultTableOptions` were incorrectly applied to audit tables on unsupported platforms (notably PostgreSQL), leading to false-positive schema differences. The changes introduce logic to ensure these options are only propagated on MySQL and MariaDB, and add comprehensive tests to prevent regressions.

**Platform-specific handling of column options:**

* Added the static method `getColumnPlatformOptions` to `PlatformHelper`, which returns `defaultTableOptions` only for MySQL/MariaDB platforms, and an empty array for others (such as PostgreSQL), preventing false schema differences.
* Updated `SchemaManager` methods (`createAuditTable` and `updateAuditTable`) to use `PlatformHelper::getColumnPlatformOptions` instead of directly accessing `defaultTableOptions`, ensuring consistent platform-aware behavior. [[1]](diffhunk://#diff-cba790889f32607300e5a697e408ca60ac209594a24efc495cbba7548b9f5defL177-R177) [[2]](diffhunk://#diff-cba790889f32607300e5a697e408ca60ac209594a24efc495cbba7548b9f5defL233-R233)

**Testing and regression prevention:**

* Introduced new tests in `PlatformHelperTest` to verify that column platform options are only set for MySQL/MariaDB and not for PostgreSQL, including regression coverage for https://github.com/DamienHarper/auditor/issues/241.
* Added imports for `MySQLPlatform` and `PostgreSQLPlatform` to support the new tests.

Fixes #241 