### PR TITLE
fix: audit ManyToMany associations when only the owning side is audited (#234)

### DIFF
--- a/src/Provider/Doctrine/Auditing/Transaction/TransactionProcessor.php
+++ b/src/Provider/Doctrine/Auditing/Transaction/TransactionProcessor.php
@@ -182,7 +182,7 @@ final class TransactionProcessor implements TransactionProcessorInterface
             'blame' => $blame,
             'diff' => [
                 'source' => $this->summarize($entityManager, $source, ['field' => $mapping['fieldName']], $meta),
-                'target' => $this->summarize($entityManager, $target, ['field' => $mapping['isOwningSide'] ? $mapping['inversedBy'] : $mapping['mappedBy']]),
+                'target' => $this->summarize($entityManager, $target, ['field' => $mapping['isOwningSide'] ? ($mapping['inversedBy'] ?? null) : ($mapping['mappedBy'] ?? null)]),
                 'is_owning_side' => $mapping['isOwningSide'],
             ],
             'table' => $meta->getTableName(),

--- a/tests/Provider/Doctrine/Issues/Issue234Test.php
+++ b/tests/Provider/Doctrine/Issues/Issue234Test.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Tests\Provider\Doctrine\Issues;
+
+use DH\Auditor\Model\Entry;
+use DH\Auditor\Model\TransactionType;
+use DH\Auditor\Provider\Doctrine\Persistence\Reader\Reader;
+use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Standard\Blog\Post;
+use DH\Auditor\Tests\Provider\Doctrine\Fixtures\Entity\Standard\Blog\Tag;
+use DH\Auditor\Tests\Provider\Doctrine\Traits\Schema\DefaultSchemaSetupTrait;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression tests for issue #234: ManyToMany association/dissociation changes are not logged
+ * when only the owning-side entity is audited (e.g. unidirectional ManyToMany, or bidirectional
+ * where only the owner carries the #[Auditable] attribute).
+ *
+ * Before the fix, TransactionHydrator required BOTH the owner and the target entity to be
+ * audited before recording an association/dissociation. This silently dropped changes for the
+ * common case where only the owning side is auditable.
+ *
+ * The audit entry is always written to the owner's audit table, so only the owner needs to
+ * be audited.
+ *
+ * @see https://github.com/DamienHarper/auditor/issues/234
+ *
+ * @internal
+ */
+#[Small]
+final class Issue234Test extends TestCase
+{
+    use DefaultSchemaSetupTrait;
+
+    /**
+     * Adding an item to a ManyToMany collection must produce an ASSOCIATE audit entry
+     * even when only the owning-side entity (Post) is audited and the target (Tag) is not.
+     */
+    public function testManyToManyAssociationIsAuditedWhenOnlyOwnerIsAuditable(): void
+    {
+        // Only the owning side is audited — Tag is intentionally NOT registered.
+        $this->provider->getConfiguration()->setEntities([
+            Post::class => ['enabled' => true],
+        ]);
+
+        $em = $this->provider->getAuditingServiceForEntity(Post::class)->getEntityManager();
+        $reader = new Reader($this->provider);
+
+        $tag = new Tag();
+        $tag->setTitle('php');
+
+        $em->persist($tag);
+
+        $post = new Post();
+        $post->setTitle('Issue 234')->setBody('Body')->setCreatedAt(new \DateTimeImmutable());
+        $em->persist($post);
+        $em->flush();
+
+        // Associate the tag — only Post is audited, Tag is not.
+        $post->addTag($tag);
+        $em->flush();
+
+        $postEntries = $reader->createQuery(Post::class)->execute();
+        $types = array_map(static fn (Entry $e): string => $e->type, $postEntries);
+
+        $this->assertContains(
+            TransactionType::ASSOCIATE,
+            $types,
+            'ASSOCIATE entry must be created even when the target entity (Tag) is not audited.'
+        );
+    }
+
+    /**
+     * Removing an item from a ManyToMany collection must produce a DISSOCIATE audit entry
+     * even when only the owning-side entity (Post) is audited and the target (Tag) is not.
+     */
+    public function testManyToManyDissociationIsAuditedWhenOnlyOwnerIsAuditable(): void
+    {
+        // Only the owning side is audited — Tag is intentionally NOT registered.
+        $this->provider->getConfiguration()->setEntities([
+            Post::class => ['enabled' => true],
+        ]);
+
+        $em = $this->provider->getAuditingServiceForEntity(Post::class)->getEntityManager();
+        $reader = new Reader($this->provider);
+
+        $tag = new Tag();
+        $tag->setTitle('php');
+
+        $em->persist($tag);
+
+        $post = new Post();
+        $post->setTitle('Issue 234')->setBody('Body')->setCreatedAt(new \DateTimeImmutable());
+        $post->getTags()->add($tag);
+        $em->persist($post);
+        $em->flush();
+
+        // Dissociate the tag — only Post is audited, Tag is not.
+        $post->removeTag($tag);
+        $em->flush();
+
+        $postEntries = $reader->createQuery(Post::class)->execute();
+        $types = array_map(static fn (Entry $e): string => $e->type, $postEntries);
+
+        $this->assertContains(
+            TransactionType::DISSOCIATE,
+            $types,
+            'DISSOCIATE entry must be created even when the target entity (Tag) is not audited.'
+        );
+    }
+
+    private function configureEntities(): void
+    {
+        $this->provider->getConfiguration()->setEntities([
+            Post::class => ['enabled' => true],
+            Tag::class => ['enabled' => true],
+        ]);
+    }
+}


### PR DESCRIPTION
This pull request fixes an issue where changes to ManyToMany associations were not audited if only the owning-side entity was audited, addressing a bug that affected unidirectional and some bidirectional relationships. The update ensures that association and dissociation events are logged even when the target entity is not audited. Additionally, a regression test is added to prevent this issue from recurring.

**Bug fix for ManyToMany auditing:**

* Updated `TransactionHydrator.php` to require only the owner entity to be audited when recording association/dissociation, allowing changes to be logged even if the target entity is not audited. This change fixes silent data loss for unidirectional ManyToMany relations and matches expected auditing behavior. [[1]](diffhunk://#diff-3c36aa4853de89260407e5a40464d452c0f6c2c879a2f95cab72e16586beda86R92-L105) [[2]](diffhunk://#diff-3c36aa4853de89260407e5a40464d452c0f6c2c879a2f95cab72e16586beda86L132)
* Removed unnecessary checks for the target entity's audited status in collection update and deletion logic, further ensuring correct logging of association changes. [[1]](diffhunk://#diff-3c36aa4853de89260407e5a40464d452c0f6c2c879a2f95cab72e16586beda86R92-L105) [[2]](diffhunk://#diff-3c36aa4853de89260407e5a40464d452c0f6c2c879a2f95cab72e16586beda86L132)
* Fixed a minor bug in `TransactionProcessor.php` by safely handling missing mapping keys when summarizing association changes.

**Testing and regression coverage:**

* Added a regression test `Issue234Test.php` to verify that ManyToMany association and dissociation changes are correctly audited when only the owning side is auditable, preventing future regressions of this issue.

**Code cleanup:**

* Removed redundant closing brackets and cleaned up code structure in `TransactionHydrator.php`. [[1]](diffhunk://#diff-3c36aa4853de89260407e5a40464d452c0f6c2c879a2f95cab72e16586beda86L115) [[2]](diffhunk://#diff-3c36aa4853de89260407e5a40464d452c0f6c2c879a2f95cab72e16586beda86L143)

Fixes #234 