### PR TITLE
feat!: refactor audit schema to v2 — ULID transaction_id, blame JSON, unified diffs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
   "require": {
     "php": ">=8.4",
     "symfony/event-dispatcher": "^8.0",
-    "symfony/options-resolver": "^8.0"
+    "symfony/options-resolver": "^8.0",
+    "symfony/uid": "^8.0"
   },
   "suggest": {
     "damienharper/auditor-bundle": "Integrate auditor library in your Symfony projects."

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -108,8 +108,8 @@ interface ConfigurationInterface
 
 > [!WARNING]
 > All DoctrineProvider classes (`DoctrineProvider`, `Configuration`, `Reader`, `Query`, filters,
-> `SchemaManager`, `AuditingService`, `StorageService`) are **deprecated** in auditor core
-> (removed in v5.0). See the [auditor-doctrine-provider](https://damienharper.github.io/auditor-docs/auditor-doctrine-provider/)
+> `SchemaManager`, `AuditingService`, `StorageService`) were **removed** from auditor core in v5.0.
+> See the [auditor-doctrine-provider](https://damienharper.github.io/auditor-docs/auditor-doctrine-provider/)
 > documentation for the current API reference.
 
 ## 📦 Models
@@ -121,20 +121,31 @@ namespace DH\Auditor\Model;
 
 final class Entry
 {
+    // Factory
     public static function fromArray(array $row): self;
-    
-    public function getId(): ?int;
-    public function getType(): string;
-    public function getObjectId(): string;
-    public function getDiscriminator(): ?string;
-    public function getTransactionHash(): ?string;
-    public function getDiffs(bool $includeMetadata = false): array;
-    public function getUserId(): int|string|null;
-    public function getUsername(): ?string;
-    public function getUserFqdn(): ?string;
-    public function getUserFirewall(): ?string;
-    public function getIp(): ?string;
-    public function getCreatedAt(): ?\DateTimeImmutable;
+
+    // Read-only properties (PHP 8.4 property hooks)
+    public private(set) ?int $id;
+    public private(set) int $schemaVersion;   // 1 = legacy, 2 = current
+    public private(set) string $type;         // 'insert', 'update', 'remove', 'associate', 'dissociate'
+    public string $objectId;                  // virtual: maps to object_id column
+    public private(set) ?string $discriminator;
+    public ?string $transactionId;            // virtual: ULID (v2) or SHA-1 fallback (v1)
+    public int|string|null $userId;           // virtual: maps to blame_id column
+    public ?array $blame;                     // virtual: decoded blame JSON
+    public ?string $username;                 // virtual: blame['username']
+    public ?string $userFqdn;                 // virtual: blame['user_fqdn']
+    public ?string $userFirewall;             // virtual: blame['user_firewall']
+    public ?string $ip;                       // virtual: blame['ip']
+    public ?array $extraData;                 // virtual: decoded extra_data JSON
+    public ?\DateTimeImmutable $createdAt;    // virtual: maps to created_at column
+
+    // Methods
+    public function getDiffs(): array;             // field changes (schema v2: changes envelope)
+    public function getDiffSource(): ?array;       // entity metadata (schema v2 only)
+    public function getDiffTarget(): ?array;       // association target (schema v2 only)
+    public function getExtraData(): ?array;
+    public function getBlame(): ?array;
 }
 ```
 

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -3,17 +3,18 @@
 > **Manage audit data via the command line**
 
 > [!NOTE]
-> These commands are provided by **DoctrineProvider**. For programmatic usage and standalone
-> registration, see [Schema Management](https://damienharper.github.io/auditor-docs/auditor-doctrine-provider/schema).
+> These commands are provided by **[auditor-doctrine-provider](https://damienharper.github.io/auditor-docs/auditor-doctrine-provider/)** (not auditor core).
+> For programmatic usage and standalone registration, see [Schema Management](https://damienharper.github.io/auditor-docs/auditor-doctrine-provider/schema).
 
-When using auditor-bundle or the standalone DoctrineProvider, two console commands are available:
+When using auditor-bundle or the standalone `auditor-doctrine-provider`, three console commands are available:
 
 ## 📋 Available Commands
 
-| Command                 | Description                            |
-|-------------------------|----------------------------------------|
-| `audit:schema:update`   | Create or update audit table schemas   |
-| `audit:clean`           | Remove old audit entries               |
+| Command                  | Description                                          |
+|--------------------------|------------------------------------------------------|
+| `audit:schema:update`    | Create or update audit tables to the current schema  |
+| `audit:schema:migrate`   | Migrate legacy v1 audit tables to schema v2          |
+| `audit:clean`            | Remove old audit entries                             |
 
 ## 🛠️ audit:schema:update
 
@@ -69,6 +70,46 @@ Run this command:
 |------|--------------------------------------------------|
 | 0    | Success (including "nothing to update")          |
 | 1    | Error or missing required options                |
+
+## 🔄 audit:schema:migrate
+
+Migrates legacy v1 audit tables to schema v2 (ULID `transaction_id`, unified `blame` JSON column).
+Safe to run multiple times; skips already-migrated tables.
+
+> [!CAUTION]
+> `audit:schema:update` refuses to run while any audit table still has the legacy v1 schema.
+> Always run `audit:schema:migrate --force` first when upgrading from auditor-bundle 7.x or earlier.
+
+### Usage
+
+```bash
+php bin/console audit:schema:migrate [options]
+```
+
+### Options
+
+| Option                       | Description                                                  |
+|------------------------------|--------------------------------------------------------------|
+| `--dump-sql`                 | Show SQL statements without executing them                   |
+| `--force`                    | Execute the DDL changes                                      |
+| `--convert-all`              | Convert transaction hashes and diffs in one pass             |
+| `--convert-transaction-hash` | Convert SHA-1 `transaction_hash` values to ULID format       |
+| `--convert-diffs`            | Convert legacy diffs JSON to the v2 envelope format          |
+
+### Examples
+
+```bash
+# Preview the DDL that would be executed
+php bin/console audit:schema:migrate --dump-sql
+
+# Full migration in one pass (recommended)
+php bin/console audit:schema:migrate --force --convert-all
+
+# DDL only (skip data conversion — safe to run first on large tables)
+php bin/console audit:schema:migrate --force
+```
+
+---
 
 ## 🧹 audit:clean
 

--- a/docs/configuration/role-checker.md
+++ b/docs/configuration/role-checker.md
@@ -84,8 +84,8 @@ You can also define view permissions directly on entities using the `#[Security]
 ```php
 <?php
 
-use DH\Auditor\Provider\Doctrine\Auditing\Annotation\Auditable;
-use DH\Auditor\Provider\Doctrine\Auditing\Annotation\Security;
+use DH\Auditor\Attribute\Auditable;
+use DH\Auditor\Attribute\Security;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -188,7 +188,7 @@ When the role checker returns `false`, an `AccessDeniedException` is thrown:
 <?php
 
 use DH\Auditor\Exception\AccessDeniedException;
-use DH\Auditor\Provider\Doctrine\Persistence\Reader\Reader;
+use DH\Auditor\Provider\Doctrine\Persistence\Reader\Reader; // from auditor-doctrine-provider
 
 $reader = new Reader($provider);
 

--- a/docs/configuration/security-provider.md
+++ b/docs/configuration/security-provider.md
@@ -8,9 +8,9 @@ The security provider captures additional contextual information about each audi
 
 When an audit entry is created, the security provider can supply:
 
-- **ip** - The client's IP address
-- **blame_user_fqdn** - The fully qualified class name of the user
-- **blame_user_firewall** - The Symfony firewall name (if applicable)
+- **ip** - The client's IP address (stored in the `blame` JSON column)
+- **user_fqdn** - The fully qualified class name of the user (stored in the `blame` JSON column)
+- **user_firewall** - The Symfony firewall name (stored in the `blame` JSON column)
 
 ## 🚀 Setting Up a Security Provider
 

--- a/docs/configuration/user-provider.md
+++ b/docs/configuration/user-provider.md
@@ -9,7 +9,7 @@ The user provider is responsible for identifying who made changes to audited ent
 When an audit entry is created, auditor can record:
 
 - **blame_id** - The unique identifier of the user
-- **blame_user** - The username or display name
+- **username** - The username or display name (stored in the `blame` JSON column)
 
 This information comes from the user provider callback.
 
@@ -37,7 +37,7 @@ $configuration->setUserProvider(function (): ?User {
     
     return new User(
         (string) $currentUser->getId(),    // User ID (stored as blame_id)
-        $currentUser->getUsername()         // Username (stored as blame_user)
+        $currentUser->getUsername()         // Username (stored in blame JSON column)
     );
 });
 ```
@@ -216,9 +216,9 @@ $query = $reader->createQuery(Post::class, ['object_id' => 123]);
 $audits = $query->execute();
 
 foreach ($audits as $entry) {
-    echo "User ID: " . $entry->getUserId();       // blame_id
-    echo "Username: " . $entry->getUsername();    // blame_user
-    echo "User FQDN: " . $entry->getUserFqdn();   // blame_user_fqdn
+    echo "User ID: " . $entry->userId;    // blame_id column
+    echo "Username: " . $entry->username; // blame JSON → username key
+    echo "User FQDN: " . $entry->userFqdn; // blame JSON → user_fqdn key
 }
 ```
 

--- a/docs/extra-data.md
+++ b/docs/extra-data.md
@@ -197,6 +197,9 @@ public function __invoke(LifecycleEvent $event): void
 The `Entry` model provides access to `extra_data` via the `extraData` property or the `getExtraData()` method:
 
 ```php
+// Reader comes from damienharper/auditor-doctrine-provider
+use DH\Auditor\Provider\Doctrine\Persistence\Reader\Reader;
+
 $reader = new Reader($provider);
 $entries = $reader->createQuery(User::class)->execute();
 

--- a/docs/providers/custom-provider.md
+++ b/docs/providers/custom-provider.md
@@ -150,17 +150,15 @@ The `$payload` array always contains these keys:
 
 | Key | Type | Description |
 |-----|------|-------------|
+| `schema_version` | `int` | Row format version (`2` for current) |
 | `type` | `string` | Operation: `'insert'`, `'update'`, `'remove'`, `'associate'`, `'dissociate'` |
 | `object_id` | `string` | Stringified primary key of the entity |
 | `discriminator` | `?string` | Doctrine inheritance discriminator (or `null`) |
-| `transaction_hash` | `?string` | Groups all changes in a single flush |
-| `diffs` | `string` | JSON-encoded field-level changes |
+| `transaction_id` | `?string` | ULID grouping all changes in a single flush |
+| `diffs` | `string` | JSON-encoded field-level changes (`{source, changes}` envelope) |
 | `extra_data` | `?string` | Optional JSON metadata (enriched by event listeners) |
 | `blame_id` | `int\|string\|null` | Authenticated user identifier |
-| `blame_user` | `?string` | Authenticated username |
-| `blame_user_fqdn` | `?string` | User class FQCN |
-| `blame_user_firewall` | `?string` | Symfony firewall name |
-| `ip` | `?string` | Client IP address |
+| `blame` | `array\|null` | Blame context: `['username', 'user_fqdn', 'user_firewall', 'ip']` |
 | `created_at` | `DateTimeImmutable` | Timestamp of the change |
 
 Providers built on Doctrine ORM also add:
@@ -392,18 +390,16 @@ final class AcmeProviderTest extends TestCase
         $provider = new AcmeProvider(new Configuration($backend));
 
         $event = new LifecycleEvent([
-            'type'                => TransactionType::INSERT,
-            'object_id'           => '42',
-            'discriminator'       => null,
-            'transaction_hash'    => 'abc123',
-            'diffs'               => '{}',
-            'extra_data'          => null,
-            'blame_id'            => null,
-            'blame_user'          => null,
-            'blame_user_fqdn'     => null,
-            'blame_user_firewall' => null,
-            'ip'                  => '127.0.0.1',
-            'created_at'          => new \DateTimeImmutable(),
+            'schema_version' => 2,
+            'type'           => TransactionType::INSERT,
+            'object_id'      => '42',
+            'discriminator'  => null,
+            'transaction_id' => '01JXXXXXXXXXXXXXXXXXXXXXXXXX',
+            'diffs'          => '{}',
+            'extra_data'     => null,
+            'blame_id'       => null,
+            'blame'          => null,
+            'created_at'     => new \DateTimeImmutable(),
         ]);
 
         $provider->persist($event);

--- a/docs/providers/doctrine/index.md
+++ b/docs/providers/doctrine/index.md
@@ -8,10 +8,10 @@ It also provides a **Reader** API to query and filter audit entries directly fro
 application.
 
 > [!WARNING]
-> The built-in `DoctrineProvider` (namespace `DH\Auditor\Provider\Doctrine\`) is **deprecated**
-> since auditor 4.1 and will be removed in v5.0.
+> The built-in `DoctrineProvider` (namespace `DH\Auditor\Provider\Doctrine\`) was **removed**
+> in auditor 5.0.
 >
-> Use the standalone **[auditor-doctrine-provider](https://damienharper.github.io/auditor-docs/auditor-doctrine-provider/)** package instead — it is a drop-in replacement
+> Use the standalone **[auditor-doctrine-provider](https://damienharper.github.io/auditor-docs/auditor-doctrine-provider/)** package — it is a drop-in replacement
 > with the same namespace and feature set.
 
 ## What it supports

--- a/docs/upgrade/v5.md
+++ b/docs/upgrade/v5.md
@@ -72,6 +72,109 @@ are no longer installed when running `composer install` on `damienharper/auditor
 | Doctrine DBAL | >= 4.0  | via `auditor-doctrine-provider` |
 | Doctrine ORM  | >= 3.2  | via `auditor-doctrine-provider` |
 
+## Schema Version 2 (Breaking Changes)
+
+auditor 5.0 also introduces a revised audit table format (**schema v2**). This section documents
+the breaking changes to the `Entry` read model and `LifecycleEvent` payload. The actual DDL
+migration is handled by `audit:schema:migrate` in `auditor-doctrine-provider`.
+
+### Removed: `$entry->transactionHash`
+
+The `transactionHash` property has been **removed**. Use `transactionId` instead.
+
+```php
+// Before (4.x)
+$entry->transactionHash;    // SHA-1 VARCHAR(40) from transaction_hash column
+
+// After (5.0)
+$entry->transactionId;      // ULID CHAR(26) from transaction_id column
+```
+
+For un-migrated v1 rows, `Entry::fromArray()` automatically falls back to `transaction_hash`
+so that `$entry->transactionId` is still populated before your tables are migrated.
+
+### Changed: blame columns unified into `$entry->blame`
+
+The four individual DB columns (`blame_user`, `blame_user_fqdn`, `blame_user_firewall`, `ip`)
+are replaced by a single `blame JSON` column. The **convenience accessors are unchanged**:
+
+```php
+$entry->username;      // blame JSON → username key
+$entry->userFqdn;      // blame JSON → user_fqdn key
+$entry->userFirewall;  // blame JSON → user_firewall key
+$entry->ip;            // blame JSON → ip key
+
+// New: access the full blame array
+$entry->blame;         // ['username' => ..., 'user_fqdn' => ..., 'user_firewall' => ..., 'ip' => ...]
+```
+
+For un-migrated v1 rows the individual columns are synthesised into a `blame` array automatically.
+
+### Changed: `getDiffs()` return value for schema v2 rows
+
+For entries written with `schema_version >= 2`, `getDiffs()` now returns the `changes` sub-array
+from the unified diffs envelope. Legacy v1 entries are returned as-is (unchanged behaviour).
+
+```php
+// schema_version = 1 (legacy): raw ['field' => ['old' => x, 'new' => y], ...] + @source stripped
+// schema_version >= 2: envelope['changes'] = ['field' => ['old' => x, 'new' => y], ...]
+$changes = $entry->getDiffs();
+```
+
+### New: `getDiffSource()` — entity metadata from the diffs envelope
+
+Returns the `source` block embedded in every v2 diffs envelope:
+
+```php
+$source = $entry->getDiffSource();
+// ['id' => '42', 'class' => 'App\Entity\Post', 'label' => 'My post', 'table' => 'post']
+// Returns null for schema_version = 1 entries.
+```
+
+### New: `getDiffTarget()` — target metadata for association entries
+
+Returns the `target` block for `associate`/`dissociate` entries (schema v2 only):
+
+```php
+$target = $entry->getDiffTarget();
+// ['id' => '7', 'class' => 'App\Entity\Tag', 'label' => 'PHP', 'table' => 'tag']
+// Returns null for non-association entries or schema_version = 1.
+```
+
+### New: `$entry->schemaVersion`
+
+```php
+$entry->schemaVersion;  // int: 1 (legacy) or 2 (current)
+```
+
+### Changed: `LifecycleEvent` payload keys
+
+| Key (4.x) | Key (5.0) | Notes |
+|---|---|---|
+| `transaction_hash` | `transaction_id` | ULID (CHAR 26) instead of SHA-1 (VARCHAR 40) |
+| `blame_user` | `blame['username']` | Nested in `blame` array |
+| `blame_user_fqdn` | `blame['user_fqdn']` | Nested in `blame` array |
+| `blame_user_firewall` | `blame['user_firewall']` | Nested in `blame` array |
+| `ip` | `blame['ip']` | Nested in `blame` array |
+| *(new)* | `schema_version` | Row format version — `2` for current |
+
+Providers implementing `persist(LifecycleEvent $event)` must update any code that reads the
+old flat keys from `$event->getPayload()`.
+
+### Migrating existing audit tables
+
+> [!IMPORTANT]
+> `audit:schema:update` refuses to run while any audit table still has the legacy v1 schema.
+> Run `audit:schema:migrate` first.
+
+```bash
+# Migrate DDL + convert transaction hashes + convert diffs in one pass
+bin/console audit:schema:migrate --force --convert-all
+```
+
+See the [auditor-doctrine-provider 2.0 upgrade guide](https://github.com/DamienHarper/auditor-doctrine-provider)
+for a step-by-step migration procedure.
+
 ## Need Help?
 
 - [GitHub Issues](https://github.com/DamienHarper/auditor/issues)

--- a/src/Event/AuditEvent.php
+++ b/src/Event/AuditEvent.php
@@ -16,14 +16,12 @@ abstract class AuditEvent extends Event
         'type',
         'object_id',
         'discriminator',
-        'transaction_hash',
+        'schema_version',
+        'transaction_id',
         'diffs',
         'extra_data',
         'blame_id',
-        'blame_user',
-        'blame_user_fqdn',
-        'blame_user_firewall',
-        'ip',
+        'blame',
         'created_at',
     ];
 
@@ -68,9 +66,19 @@ abstract class AuditEvent extends Event
      */
     private function normalizePayload(array $payload): array
     {
-        // extra_data is optional - default to null if not provided
+        // extra_data is optional — default to null if not provided
         if (!\array_key_exists('extra_data', $payload)) {
             $payload['extra_data'] = null;
+        }
+
+        // blame is optional — default to null if not provided (unauthenticated contexts)
+        if (!\array_key_exists('blame', $payload)) {
+            $payload['blame'] = null;
+        }
+
+        // schema_version defaults to 2 (new format) if not explicitly set
+        if (!\array_key_exists('schema_version', $payload)) {
+            $payload['schema_version'] = 2;
         }
 
         return $payload;

--- a/src/Model/Entry.php
+++ b/src/Model/Entry.php
@@ -13,6 +13,8 @@ final class Entry
 {
     public private(set) ?int $id = null;
 
+    public private(set) int $schemaVersion = 1;
+
     public private(set) string $type = '';
 
     public string $objectId {
@@ -21,27 +23,20 @@ final class Entry
 
     public private(set) ?string $discriminator = null;
 
-    public ?string $transactionHash {
-        get => $this->transaction_hash;
+    public ?string $transactionId {
+        get => $this->transaction_id;
     }
 
     public int|string|null $userId {
         get => $this->blame_id;
     }
 
-    public ?string $username {
-        get => $this->blame_user;
+    /**
+     * Returns the decoded blame context: username, user_fqdn, user_firewall, ip.
+     */
+    public ?array $blame {
+        get => $this->getBlame();
     }
-
-    public ?string $userFqdn {
-        get => $this->blame_user_fqdn;
-    }
-
-    public ?string $userFirewall {
-        get => $this->blame_user_firewall;
-    }
-
-    public private(set) ?string $ip = null;
 
     public ?array $extraData {
         get => $this->getExtraData();
@@ -53,7 +48,7 @@ final class Entry
 
     private string $object_id = '';
 
-    private ?string $transaction_hash = null;
+    private ?string $transaction_id = null;
 
     private string $diffs = '{}';
 
@@ -61,25 +56,69 @@ final class Entry
 
     private int|string|null $blame_id = null;
 
-    private ?string $blame_user = null;
-
-    private ?string $blame_user_fqdn = null;
-
-    private ?string $blame_user_firewall = null;
+    /**
+     * Raw JSON string from the `blame` DB column — decoded via $blame virtual property.
+     */
+    private ?string $blame_raw = null;
 
     private ?\DateTimeImmutable $created_at = null;
 
     /**
-     * Get diff values.
+     * Get diff changes for the current entry.
+     *
+     * For entries written with schema_version >= 2 (new unified format), returns
+     * the 'changes' sub-array: ['field' => ['old' => x, 'new' => y], ...].
+     *
+     * For legacy entries (schema_version = 1, old format), returns the raw decoded
+     * diffs array as-is so that existing consumers continue to work unchanged.
      */
-    public function getDiffs(bool $includeMetadata = false): array
+    public function getDiffs(): array
     {
-        $diffs = $this->sort(json_decode($this->diffs, true, 512, JSON_THROW_ON_ERROR));  // @phpstan-ignore-line
-        if (!$includeMetadata) {
-            unset($diffs['@source']);
+        $diffs = $this->decodeJson($this->diffs);
+
+        if ($this->schemaVersion >= 2) {
+            return \is_array($diffs['changes'] ?? null) ? $diffs['changes'] : [];
         }
 
-        return $diffs;
+        // Legacy format (schema_version = 1): return raw array, stripping @source metadata
+        unset($diffs['@source']);
+
+        return $this->sort($diffs);
+    }
+
+    /**
+     * Returns the 'source' metadata block from the diffs envelope (schema_version >= 2 only).
+     *
+     * Contains: id, class, label, table of the audited entity.
+     * Returns null for legacy entries (schema_version = 1).
+     */
+    public function getDiffSource(): ?array
+    {
+        if ($this->schemaVersion < 2) {
+            return null;
+        }
+
+        $diffs = $this->decodeJson($this->diffs);
+        $source = $diffs['source'] ?? null;
+
+        return \is_array($source) ? $source : null;
+    }
+
+    /**
+     * Returns the 'target' metadata block for ASSOCIATE/DISSOCIATE entries (schema_version >= 2 only).
+     *
+     * Returns null for non-association entries or legacy entries.
+     */
+    public function getDiffTarget(): ?array
+    {
+        if ($this->schemaVersion < 2) {
+            return null;
+        }
+
+        $diffs = $this->decodeJson($this->diffs);
+        $target = $diffs['target'] ?? null;
+
+        return \is_array($target) ? $target : null;
     }
 
     public function getExtraData(): ?array
@@ -88,7 +127,16 @@ final class Entry
             return null;
         }
 
-        return json_decode($this->extra_data, true, 512, JSON_THROW_ON_ERROR);
+        return $this->decodeJson($this->extra_data);
+    }
+
+    public function getBlame(): ?array
+    {
+        if (null === $this->blame_raw) {
+            return null;
+        }
+
+        return $this->decodeJson($this->blame_raw);
     }
 
     public static function fromArray(array $row): self
@@ -96,12 +144,37 @@ final class Entry
         $entry = new self();
 
         foreach ($row as $key => $value) {
+            // The 'blame' DB column maps to the $blame_raw backing field (the $blame
+            // virtual property uses that name, so we cannot set it directly via property_exists).
+            if ('blame' === $key) {
+                $entry->blame_raw = $value;
+
+                continue;
+            }
+
+            // The 'schema_version' DB column maps to the camelCase $schemaVersion property.
+            if ('schema_version' === $key) {
+                $entry->schemaVersion = (int) $value;
+
+                continue;
+            }
+
             if (property_exists($entry, $key)) {
                 $entry->{$key} = 'id' === $key ? (int) $value : $value;
             }
         }
 
         return $entry;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(string $json): array
+    {
+        $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+        return \is_array($decoded) ? $decoded : [];
     }
 
     private function sort(array $array): array

--- a/src/Model/Entry.php
+++ b/src/Model/Entry.php
@@ -200,8 +200,15 @@ final class Entry
                 continue;
             }
 
-            // v1 legacy transaction_hash column — superseded by transaction_id in schema v2; ignore it.
+            // v1 legacy transaction_hash column — superseded by transaction_id in schema v2.
+            // When no transaction_id has been set yet (un-migrated v1 table), fall back to
+            // transaction_hash so that $entry->transactionId is non-null and templates can
+            // display and link to the transaction stream.
             if ('transaction_hash' === $key) {
+                if (null === $entry->transaction_id && null !== $value && '' !== $value) {
+                    $entry->transaction_id = $value;
+                }
+
                 continue;
             }
 

--- a/src/Model/Entry.php
+++ b/src/Model/Entry.php
@@ -38,6 +38,26 @@ final class Entry
         get => $this->getBlame();
     }
 
+    /** Convenience accessor for $blame['username']. */
+    public ?string $username {
+        get => $this->getBlame()['username'] ?? null;
+    }
+
+    /** Convenience accessor for $blame['user_fqdn']. */
+    public ?string $userFqdn {
+        get => $this->getBlame()['user_fqdn'] ?? null;
+    }
+
+    /** Convenience accessor for $blame['user_firewall']. */
+    public ?string $userFirewall {
+        get => $this->getBlame()['user_firewall'] ?? null;
+    }
+
+    /** Convenience accessor for $blame['ip']. */
+    public ?string $ip {
+        get => $this->getBlame()['ip'] ?? null;
+    }
+
     public ?array $extraData {
         get => $this->getExtraData();
     }
@@ -77,7 +97,15 @@ final class Entry
         $diffs = $this->decodeJson($this->diffs);
 
         if ($this->schemaVersion >= 2) {
-            return \is_array($diffs['changes'] ?? null) ? $diffs['changes'] : [];
+            // Association/dissociation entries have no 'changes' key — return the full diff
+            // (source, target, is_owning_side, join_table) so consumers can inspect it uniformly.
+            if (!\array_key_exists('changes', $diffs)) {
+                return $this->sort($diffs);
+            }
+
+            $changes = \is_array($diffs['changes']) ? $diffs['changes'] : [];
+
+            return $this->sort($changes);
         }
 
         // Legacy format (schema_version = 1): return raw array, stripping @source metadata
@@ -101,7 +129,7 @@ final class Entry
         $diffs = $this->decodeJson($this->diffs);
         $source = $diffs['source'] ?? null;
 
-        return \is_array($source) ? $source : null;
+        return \is_array($source) ? $this->sort($source) : null;
     }
 
     /**
@@ -177,8 +205,26 @@ final class Entry
         return \is_array($decoded) ? $decoded : [];
     }
 
+    /**
+     * Recursively sorts an array by key, preserving the old-before-new insertion order for
+     * 'old'/'new' diff leaf pairs, but still recursively sorting any array values within them.
+     */
     private function sort(array $array): array
     {
+        // Leaf diff pairs: exactly two keys 'old' and 'new' — keep old before new,
+        // but still recurse into their array values (e.g. DiffLabel value objects).
+        if (2 === \count($array) && \array_key_exists('old', $array) && \array_key_exists('new', $array)) {
+            if (\is_array($array['old'])) {
+                $array['old'] = $this->sort($array['old']);
+            }
+
+            if (\is_array($array['new'])) {
+                $array['new'] = $this->sort($array['new']);
+            }
+
+            return $array;
+        }
+
         ksort($array);
         foreach ($array as $key => $value) {
             if (\is_array($value)) {

--- a/src/Model/Entry.php
+++ b/src/Model/Entry.php
@@ -213,10 +213,10 @@ final class Entry
         // If no v2 'blame' column was present but v1 individual columns were, synthesize blame_raw.
         if (null === $entry->blame_raw && [] !== $legacyBlame) {
             $blameData = array_filter([
-                'username'      => $legacyBlame['blame_user'] ?? null,
-                'user_fqdn'     => $legacyBlame['blame_user_fqdn'] ?? null,
+                'username' => $legacyBlame['blame_user'] ?? null,
+                'user_fqdn' => $legacyBlame['blame_user_fqdn'] ?? null,
                 'user_firewall' => $legacyBlame['blame_user_firewall'] ?? null,
-                'ip'            => $legacyBlame['ip'] ?? null,
+                'ip' => $legacyBlame['ip'] ?? null,
             ], static fn (mixed $v): bool => null !== $v);
 
             if ([] !== $blameData) {

--- a/src/Model/Entry.php
+++ b/src/Model/Entry.php
@@ -171,6 +171,10 @@ final class Entry
     {
         $entry = new self();
 
+        // Collect v1 legacy blame columns so we can synthesize blame_raw if no
+        // v2 'blame' JSON column is present in the row (un-migrated v1 tables).
+        $legacyBlame = [];
+
         foreach ($row as $key => $value) {
             // The 'blame' DB column maps to the $blame_raw backing field (the $blame
             // virtual property uses that name, so we cannot set it directly via property_exists).
@@ -187,8 +191,36 @@ final class Entry
                 continue;
             }
 
+            // v1 legacy blame columns — absorbed into the blame JSON in schema v2.
+            // Collect them and synthesize blame_raw below; never assign to the
+            // read-only virtual $ip property or the non-existent $blame_user* properties.
+            if (\in_array($key, ['blame_user', 'blame_user_fqdn', 'blame_user_firewall', 'ip'], true)) {
+                $legacyBlame[$key] = $value;
+
+                continue;
+            }
+
+            // v1 legacy transaction_hash column — superseded by transaction_id in schema v2; ignore it.
+            if ('transaction_hash' === $key) {
+                continue;
+            }
+
             if (property_exists($entry, $key)) {
                 $entry->{$key} = 'id' === $key ? (int) $value : $value;
+            }
+        }
+
+        // If no v2 'blame' column was present but v1 individual columns were, synthesize blame_raw.
+        if (null === $entry->blame_raw && [] !== $legacyBlame) {
+            $blameData = array_filter([
+                'username'      => $legacyBlame['blame_user'] ?? null,
+                'user_fqdn'     => $legacyBlame['blame_user_fqdn'] ?? null,
+                'user_firewall' => $legacyBlame['blame_user_firewall'] ?? null,
+                'ip'            => $legacyBlame['ip'] ?? null,
+            ], static fn (mixed $v): bool => null !== $v);
+
+            if ([] !== $blameData) {
+                $entry->blame_raw = json_encode($blameData, JSON_THROW_ON_ERROR);
             }
         }
 

--- a/src/Model/Transaction.php
+++ b/src/Model/Transaction.php
@@ -10,13 +10,14 @@ use DH\Auditor\Event\Dto\InsertEventDto;
 use DH\Auditor\Event\Dto\RemoveEventDto;
 use DH\Auditor\Event\Dto\UpdateEventDto;
 use DH\Auditor\Tests\Model\TransactionTest;
+use Symfony\Component\Uid\Ulid;
 
 /**
  * @see TransactionTest
  */
 class Transaction implements TransactionInterface
 {
-    private ?string $transaction_hash = null;
+    private ?string $transaction_id = null;
 
     /**
      * @var InsertEventDto[]
@@ -44,15 +45,15 @@ class Transaction implements TransactionInterface
     private array $dissociated = [];
 
     /**
-     * Returns transaction hash.
+     * Returns transaction ID (ULID).
      */
-    public function getTransactionHash(): string
+    public function getTransactionId(): string
     {
-        if (null === $this->transaction_hash) {
-            $this->transaction_hash = sha1(uniqid('tid', true));
+        if (null === $this->transaction_id) {
+            $this->transaction_id = (string) new Ulid();
         }
 
-        return $this->transaction_hash;
+        return $this->transaction_id;
     }
 
     /**
@@ -97,7 +98,7 @@ class Transaction implements TransactionInterface
 
     public function reset(): void
     {
-        $this->transaction_hash = null;
+        $this->transaction_id = null;
         $this->inserted = [];
         $this->updated = [];
         $this->removed = [];

--- a/src/Model/TransactionInterface.php
+++ b/src/Model/TransactionInterface.php
@@ -7,9 +7,9 @@ namespace DH\Auditor\Model;
 interface TransactionInterface
 {
     /**
-     * Returns transaction hash.
+     * Returns transaction ID (ULID).
      */
-    public function getTransactionHash(): string;
+    public function getTransactionId(): string;
 
     public function getInserted(): array;
 

--- a/tests/Event/LifecycleEventTest.php
+++ b/tests/Event/LifecycleEventTest.php
@@ -20,21 +20,19 @@ final class LifecycleEventTest extends TestCase
     use AuditorTrait;
 
     /**
-     * @var array<string, class-string<AuditEventSubscriber>|string>
+     * @var array<string, class-string<AuditEventSubscriber>|int|string>
      */
     private const array PAYLOAD = [
         'entity' => AuditEventSubscriber::class,
         'table' => '',
+        'schema_version' => 2,
         'type' => '',
         'object_id' => '',
         'discriminator' => '',
-        'transaction_hash' => '',
+        'transaction_id' => '',
         'diffs' => '',
         'blame_id' => '',
-        'blame_user' => '',
-        'blame_user_fqdn' => '',
-        'blame_user_firewall' => '',
-        'ip' => '',
+        'blame' => '',
         'extra_data' => '',
         'created_at' => '',
     ];
@@ -69,17 +67,15 @@ final class LifecycleEventTest extends TestCase
         $payload = [
             'entity' => AuditEventSubscriber::class,
             'table' => '',
+            'schema_version' => 2,
             'type' => '',
             'object_id' => '',
             'discriminator' => '',
-            'transaction_hash' => '',
+            'transaction_id' => '',
             'diffs' => '',
             'extra_data' => '',
             'blame_id' => '',
-            'blame_user' => '',
-            'blame_user_fqdn' => '',
-            'blame_user_firewall' => '',
-            'ip' => '',
+            'blame' => '',
             'created_at' => '',
         ];
 
@@ -95,17 +91,15 @@ final class LifecycleEventTest extends TestCase
         $payload = [
             'entity' => AuditEventSubscriber::class,
             'table' => '',
+            'schema_version' => 2,
             'type' => '',
             'object_id' => '',
             'discriminator' => '',
-            'transaction_hash' => '',
+            'transaction_id' => '',
             'diffs' => '',
             'extra_data' => '',
             'blame_id' => '',
-            'blame_user' => '',
-            'blame_user_fqdn' => '',
-            'blame_user_firewall' => '',
-            'ip' => '',
+            'blame' => '',
             'created_at' => '',
         ];
 
@@ -118,24 +112,20 @@ final class LifecycleEventTest extends TestCase
 
     public function testPayloadWithoutExtraDataIsNormalized(): void
     {
-        // Payload without extra_data key
         $payload = [
             'entity' => AuditEventSubscriber::class,
             'table' => '',
+            'schema_version' => 2,
             'type' => '',
             'object_id' => '',
             'discriminator' => '',
-            'transaction_hash' => '',
+            'transaction_id' => '',
             'diffs' => '',
             'blame_id' => '',
-            'blame_user' => '',
-            'blame_user_fqdn' => '',
-            'blame_user_firewall' => '',
-            'ip' => '',
+            'blame' => '',
             'created_at' => '',
         ];
 
-        // Should not throw, extra_data should be auto-added as null
         $event = new LifecycleEvent($payload);
         $resultPayload = $event->getPayload();
 
@@ -147,28 +137,67 @@ final class LifecycleEventTest extends TestCase
     {
         $event = new LifecycleEvent(self::PAYLOAD);
 
-        // Payload without extra_data key
+        $payload = [
+            'entity' => AuditEventSubscriber::class,
+            'table' => '',
+            'schema_version' => 2,
+            'type' => '',
+            'object_id' => '',
+            'discriminator' => '',
+            'transaction_id' => '',
+            'diffs' => '',
+            'blame_id' => '',
+            'blame' => '',
+            'created_at' => '',
+        ];
+
+        $event->setPayload($payload);
+        $resultPayload = $event->getPayload();
+
+        $this->assertArrayHasKey('extra_data', $resultPayload);
+        $this->assertNull($resultPayload['extra_data']);
+    }
+
+    public function testPayloadWithoutBlameIsNormalized(): void
+    {
+        $payload = [
+            'entity' => AuditEventSubscriber::class,
+            'table' => '',
+            'schema_version' => 2,
+            'type' => '',
+            'object_id' => '',
+            'discriminator' => '',
+            'transaction_id' => '',
+            'diffs' => '',
+            'blame_id' => '',
+            'created_at' => '',
+        ];
+
+        $event = new LifecycleEvent($payload);
+        $resultPayload = $event->getPayload();
+
+        $this->assertArrayHasKey('blame', $resultPayload);
+        $this->assertNull($resultPayload['blame']);
+    }
+
+    public function testPayloadWithoutSchemaVersionIsNormalized(): void
+    {
         $payload = [
             'entity' => AuditEventSubscriber::class,
             'table' => '',
             'type' => '',
             'object_id' => '',
             'discriminator' => '',
-            'transaction_hash' => '',
+            'transaction_id' => '',
             'diffs' => '',
             'blame_id' => '',
-            'blame_user' => '',
-            'blame_user_fqdn' => '',
-            'blame_user_firewall' => '',
-            'ip' => '',
             'created_at' => '',
         ];
 
-        // Should not throw, extra_data should be auto-added as null
-        $event->setPayload($payload);
+        $event = new LifecycleEvent($payload);
         $resultPayload = $event->getPayload();
 
-        $this->assertArrayHasKey('extra_data', $resultPayload);
-        $this->assertNull($resultPayload['extra_data']);
+        $this->assertArrayHasKey('schema_version', $resultPayload);
+        $this->assertSame(2, $resultPayload['schema_version']);
     }
 }

--- a/tests/EventSubscriber/AuditEventSubscriberTest.php
+++ b/tests/EventSubscriber/AuditEventSubscriberTest.php
@@ -24,17 +24,15 @@ final class AuditEventSubscriberTest extends TestCase
         $payload = [
             'entity' => AuditEventSubscriber::class,
             'table' => '',
+            'schema_version' => 2,
             'type' => '',
             'object_id' => '',
             'discriminator' => '',
-            'transaction_hash' => '',
+            'transaction_id' => '',
             'diffs' => '',
             'extra_data' => '',
             'blame_id' => '',
-            'blame_user' => '',
-            'blame_user_fqdn' => '',
-            'blame_user_firewall' => '',
-            'ip' => '',
+            'blame' => '',
             'created_at' => '',
         ];
 
@@ -53,17 +51,15 @@ final class AuditEventSubscriberTest extends TestCase
         $payload = [
             'entity' => AuditEventSubscriber::class,
             'table' => '',
+            'schema_version' => 2,
             'type' => '',
             'object_id' => '',
             'discriminator' => '',
-            'transaction_hash' => '',
+            'transaction_id' => '',
             'diffs' => '',
             'extra_data' => '',
             'blame_id' => '',
-            'blame_user' => '',
-            'blame_user_fqdn' => '',
-            'blame_user_firewall' => '',
-            'ip' => '',
+            'blame' => '',
             'created_at' => '',
         ];
 

--- a/tests/Model/EntryTest.php
+++ b/tests/Model/EntryTest.php
@@ -188,4 +188,35 @@ final class EntryTest extends TestCase
 
         $this->assertNull($entry->transactionId);
     }
+
+    public function testFromArrayWithLegacyV1Row(): void
+    {
+        // Simulate a SELECT * row from a v1 table (or a transitional table with both
+        // old and new columns present). fromArray() must not throw on read-only virtual
+        // properties like $ip, and must synthesize blame_raw from the individual columns.
+        $entry = Entry::fromArray([
+            'id' => 42,
+            'schema_version' => 1,
+            'type' => 'update',
+            'object_id' => '19',
+            'transaction_hash' => 'abc123',
+            'transaction_id' => null,
+            'blame_id' => 'user@example.com',
+            'blame_user' => 'John Doe',
+            'blame_user_fqdn' => 'App\\Entity\\User',
+            'blame_user_firewall' => 'main',
+            'ip' => '1.2.3.4',
+            'blame' => null,
+            'diffs' => '{}',
+            'created_at' => new \DateTimeImmutable(),
+        ]);
+
+        $this->assertSame(42, $entry->id);
+        $this->assertSame(1, $entry->schemaVersion);
+        $this->assertNull($entry->transactionId, 'Legacy transaction_hash is not mapped to transactionId.');
+        $this->assertSame('John Doe', $entry->username, 'username synthesized from blame_user.');
+        $this->assertSame('App\\Entity\\User', $entry->userFqdn, 'userFqdn synthesized from blame_user_fqdn.');
+        $this->assertSame('main', $entry->userFirewall, 'userFirewall synthesized from blame_user_firewall.');
+        $this->assertSame('1.2.3.4', $entry->ip, 'ip synthesized from legacy ip column.');
+    }
 }

--- a/tests/Model/EntryTest.php
+++ b/tests/Model/EntryTest.php
@@ -203,7 +203,7 @@ final class EntryTest extends TestCase
             'transaction_id' => null,
             'blame_id' => 'user@example.com',
             'blame_user' => 'John Doe',
-            'blame_user_fqdn' => 'App\\Entity\\User',
+            'blame_user_fqdn' => 'App\Entity\User',
             'blame_user_firewall' => 'main',
             'ip' => '1.2.3.4',
             'blame' => null,
@@ -215,7 +215,7 @@ final class EntryTest extends TestCase
         $this->assertSame(1, $entry->schemaVersion);
         $this->assertNull($entry->transactionId, 'Legacy transaction_hash is not mapped to transactionId.');
         $this->assertSame('John Doe', $entry->username, 'username synthesized from blame_user.');
-        $this->assertSame('App\\Entity\\User', $entry->userFqdn, 'userFqdn synthesized from blame_user_fqdn.');
+        $this->assertSame('App\Entity\User', $entry->userFqdn, 'userFqdn synthesized from blame_user_fqdn.');
         $this->assertSame('main', $entry->userFirewall, 'userFirewall synthesized from blame_user_firewall.');
         $this->assertSame('1.2.3.4', $entry->ip, 'ip synthesized from legacy ip column.');
     }

--- a/tests/Model/EntryTest.php
+++ b/tests/Model/EntryTest.php
@@ -16,30 +16,36 @@ final class EntryTest extends TestCase
 {
     public function testAccessors(): void
     {
+        $blame = json_encode([
+            'username' => 'John Doe',
+            'user_fqdn' => 'Acme\User',
+            'user_firewall' => 'main',
+            'ip' => '1.2.3.4',
+        ]);
+
         $attributes = [
             'id' => 1,
+            'schema_version' => 2,
             'type' => 'type',
             'object_id' => '1',
             'diffs' => '{}',
             'blame_id' => 1,
-            'blame_user' => 'John Doe',
-            'blame_user_fqdn' => 'Acme\User',
-            'blame_user_firewall' => 'main',
-            'ip' => '1.2.3.4',
+            'blame' => $blame,
             'created_at' => new \DateTimeImmutable(),
         ];
 
         $entry = Entry::fromArray($attributes);
 
         $this->assertSame(1, $entry->id, 'Entry::id is ok.');
+        $this->assertSame(2, $entry->schemaVersion, 'Entry::schemaVersion is ok.');
         $this->assertSame('type', $entry->type, 'Entry::type is ok.');
         $this->assertSame('1', $entry->objectId, 'Entry::objectId is ok.');
-        $this->assertSame([], $entry->getDiffs(), 'Entry::getDiffs() is ok.');
+        $this->assertSame([], $entry->getDiffs(), 'Entry::getDiffs() returns empty array for empty diffs.');
         $this->assertSame(1, $entry->userId, 'Entry::userId is ok.');
-        $this->assertSame('John Doe', $entry->username, 'Entry::username is ok.');
-        $this->assertSame('Acme\User', $entry->userFqdn, 'Entry::userFqdn is ok.');
-        $this->assertSame('main', $entry->userFirewall, 'Entry::userFirewall is ok.');
-        $this->assertSame('1.2.3.4', $entry->ip, 'Entry::ip is ok.');
+        $this->assertSame('John Doe', $entry->blame['username'], 'Entry::blame[username] is ok.');
+        $this->assertSame('Acme\User', $entry->blame['user_fqdn'], 'Entry::blame[user_fqdn] is ok.');
+        $this->assertSame('main', $entry->blame['user_firewall'], 'Entry::blame[user_firewall] is ok.');
+        $this->assertSame('1.2.3.4', $entry->blame['ip'], 'Entry::blame[ip] is ok.');
         $this->assertSame($attributes['created_at'], $entry->createdAt, 'Entry::createdAt is ok.');
     }
 
@@ -48,7 +54,95 @@ final class EntryTest extends TestCase
         $entry = new Entry();
 
         $this->assertNull($entry->userId, 'Entry::userId is ok with undefined user.');
-        $this->assertNull($entry->username, 'Entry::username is ok with undefined user.');
+        $this->assertNull($entry->blame, 'Entry::blame is null with undefined user.');
+    }
+
+    public function testSchemaVersionDefaultsToOne(): void
+    {
+        $entry = new Entry();
+
+        $this->assertSame(1, $entry->schemaVersion, 'Entry::schemaVersion defaults to 1.');
+    }
+
+    public function testGetDiffsLegacyFormat(): void
+    {
+        // schema_version = 1: old format, returns raw decoded array (minus @source)
+        $entry = Entry::fromArray([
+            'schema_version' => 1,
+            'diffs' => json_encode([
+                '@source' => ['id' => 1, 'class' => 'App\Entity\Foo', 'label' => 'Foo', 'table' => 'foo'],
+                'name' => ['new' => 'Alice'],
+            ]),
+        ]);
+
+        $diffs = $entry->getDiffs();
+        $this->assertArrayNotHasKey('@source', $diffs, 'getDiffs() strips @source in legacy format.');
+        $this->assertArrayHasKey('name', $diffs, 'getDiffs() returns field diffs in legacy format.');
+    }
+
+    public function testGetDiffsNewFormat(): void
+    {
+        // schema_version = 2: unified envelope, returns 'changes' sub-array
+        $entry = Entry::fromArray([
+            'schema_version' => 2,
+            'diffs' => json_encode([
+                'source' => ['id' => '1', 'class' => 'App\Entity\Foo', 'label' => 'Foo', 'table' => 'foo'],
+                'changes' => [
+                    'name' => ['old' => 'Alice', 'new' => 'Bob'],
+                ],
+            ]),
+        ]);
+
+        $diffs = $entry->getDiffs();
+        $this->assertSame(['name' => ['old' => 'Alice', 'new' => 'Bob']], $diffs);
+    }
+
+    public function testGetDiffSource(): void
+    {
+        $source = ['id' => '1', 'class' => 'App\Entity\Foo', 'label' => 'Foo', 'table' => 'foo'];
+
+        $entry = Entry::fromArray([
+            'schema_version' => 2,
+            'diffs' => json_encode(['source' => $source, 'changes' => []]),
+        ]);
+
+        $this->assertSame($source, $entry->getDiffSource());
+    }
+
+    public function testGetDiffSourceReturnsNullForLegacyEntry(): void
+    {
+        $entry = Entry::fromArray([
+            'schema_version' => 1,
+            'diffs' => '{"name": {"new": "Alice"}}',
+        ]);
+
+        $this->assertNull($entry->getDiffSource());
+    }
+
+    public function testGetDiffTarget(): void
+    {
+        $target = ['id' => '5', 'class' => 'App\Entity\Tag', 'label' => 'php', 'table' => 'tag', 'field' => 'posts'];
+
+        $entry = Entry::fromArray([
+            'schema_version' => 2,
+            'diffs' => json_encode([
+                'source' => ['id' => '1', 'class' => 'App\Entity\Post', 'label' => 'First post', 'table' => 'post', 'field' => 'tags'],
+                'target' => $target,
+                'is_owning_side' => true,
+            ]),
+        ]);
+
+        $this->assertSame($target, $entry->getDiffTarget());
+    }
+
+    public function testGetDiffTargetReturnsNullForLegacyEntry(): void
+    {
+        $entry = Entry::fromArray([
+            'schema_version' => 1,
+            'diffs' => '{"source": {}, "target": {}}',
+        ]);
+
+        $this->assertNull($entry->getDiffTarget());
     }
 
     public function testGetDiffsReturnsAnArray(): void
@@ -80,5 +174,19 @@ final class EntryTest extends TestCase
         $entry = Entry::fromArray(['extra_data' => json_encode($data)]);
 
         $this->assertSame($data, $entry->getExtraData(), 'Entry::getExtraData() handles nested data.');
+    }
+
+    public function testTransactionId(): void
+    {
+        $entry = Entry::fromArray(['transaction_id' => '01HXYZ1234567890ABCDEFGHIJ']);
+
+        $this->assertSame('01HXYZ1234567890ABCDEFGHIJ', $entry->transactionId);
+    }
+
+    public function testTransactionIdIsNullByDefault(): void
+    {
+        $entry = new Entry();
+
+        $this->assertNull($entry->transactionId);
     }
 }

--- a/tests/Model/EntryTest.php
+++ b/tests/Model/EntryTest.php
@@ -99,14 +99,13 @@ final class EntryTest extends TestCase
 
     public function testGetDiffSource(): void
     {
-        $source = ['id' => '1', 'class' => 'App\Entity\Foo', 'label' => 'Foo', 'table' => 'foo'];
-
         $entry = Entry::fromArray([
             'schema_version' => 2,
-            'diffs' => json_encode(['source' => $source, 'changes' => []]),
+            'diffs' => json_encode(['source' => ['id' => '1', 'class' => 'App\Entity\Foo', 'label' => 'Foo', 'table' => 'foo'], 'changes' => []]),
         ]);
 
-        $this->assertSame($source, $entry->getDiffSource());
+        // getDiffSource() returns keys sorted alphabetically
+        $this->assertSame(['class' => 'App\Entity\Foo', 'id' => '1', 'label' => 'Foo', 'table' => 'foo'], $entry->getDiffSource());
     }
 
     public function testGetDiffSourceReturnsNullForLegacyEntry(): void

--- a/tests/Model/TransactionTest.php
+++ b/tests/Model/TransactionTest.php
@@ -7,6 +7,7 @@ namespace DH\Auditor\Tests\Model;
 use DH\Auditor\Model\Transaction;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Ulid;
 
 /**
  * @internal
@@ -18,13 +19,36 @@ final class TransactionTest extends TestCase
 
     protected function tearDown(): void {}
 
-    public function testGetTransactionHash(): void
+    public function testGetTransactionId(): void
     {
         $transaction = new Transaction();
 
-        $transaction_hash = $transaction->getTransactionHash();
-        $this->assertNotNull($transaction_hash, 'transaction_hash is not null');
-        $this->assertIsString($transaction_hash, 'transaction_hash is a string');
-        $this->assertSame(40, mb_strlen($transaction_hash), 'transaction_hash is a string of 40 characters');
+        $transaction_id = $transaction->getTransactionId();
+        $this->assertNotNull($transaction_id, 'transaction_id is not null');
+        $this->assertIsString($transaction_id, 'transaction_id is a string');
+        $this->assertSame(26, mb_strlen($transaction_id), 'transaction_id is a string of 26 characters (ULID)');
+        $this->assertTrue(Ulid::isValid($transaction_id), 'transaction_id is a valid ULID');
+    }
+
+    public function testGetTransactionIdIsStable(): void
+    {
+        $transaction = new Transaction();
+
+        $this->assertSame(
+            $transaction->getTransactionId(),
+            $transaction->getTransactionId(),
+            'transaction_id is stable within the same transaction'
+        );
+    }
+
+    public function testResetClearsTransactionId(): void
+    {
+        $transaction = new Transaction();
+
+        $id1 = $transaction->getTransactionId();
+        $transaction->reset();
+        $id2 = $transaction->getTransactionId();
+
+        $this->assertNotSame($id1, $id2, 'reset() generates a new transaction_id');
     }
 }


### PR DESCRIPTION
## Summary

- Replace `transaction_hash` (SHA1 VARCHAR 40) with `transaction_id` (ULID CHAR 26) for sortable, universally unique transaction identifiers
- Consolidate flat blame columns (`blame_user`, `blame_user_fqdn`, `blame_user_firewall`, `ip`) into a single `blame` JSON column
- Add `schema_version` SMALLINT column (default 2) to distinguish legacy format rows from new ones
- Refactor `Entry` model with PHP 8.4 property hooks: add `$blame`, `$transactionId`, `$schemaVersion`, plus convenience accessors `$username`, `$ip`, `$userFqdn`, `$userFirewall`
- Unify `AuditEvent` payload contract: remove old flat blame keys, add `schema_version`, `transaction_id`, `blame`

## Breaking changes

- `TransactionInterface::getTransactionHash()` renamed to `getTransactionId()`
- `AuditEvent` required payload keys updated (see `REQUIRED_PAYLOAD_KEYS`)
- `Entry::$transactionHash` no longer exists — use `$transactionId`
