### PR TITLE
feat: AuditDiff and AuditDiffCollection typed value objects

### DIFF
--- a/src/Model/AuditDiff.php
+++ b/src/Model/AuditDiff.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Model;
+
+use DH\Auditor\Tests\Model\AuditDiffTest;
+
+/**
+ * Immutable value object representing a single field change in an audit entry.
+ *
+ * @see AuditDiffTest
+ */
+final class AuditDiff
+{
+    public function __construct(
+        private readonly string $field,
+        private readonly mixed $oldValue,
+        private readonly mixed $newValue,
+    ) {}
+
+    public function getField(): string
+    {
+        return $this->field;
+    }
+
+    public function getOldValue(): mixed
+    {
+        return $this->oldValue;
+    }
+
+    public function getNewValue(): mixed
+    {
+        return $this->newValue;
+    }
+
+    /**
+     * Returns true when the field was added (old is null, new is set).
+     * Reliable for schema_version >= 2 entries where 'old' is always explicit.
+     * For legacy entries (schema_version = 1 INSERT), old is null by convention.
+     */
+    public function wasAdded(): bool
+    {
+        return null === $this->oldValue && null !== $this->newValue;
+    }
+
+    /**
+     * Returns true when the field was removed (old is set, new is null).
+     * Reliable for schema_version >= 2 entries where 'new' is always explicit.
+     */
+    public function wasRemoved(): bool
+    {
+        return null !== $this->oldValue && null === $this->newValue;
+    }
+
+    /**
+     * Returns true when the old or new value is a relation descriptor array
+     * with keys: id, class, label, table.
+     */
+    public function isRelation(): bool
+    {
+        return self::isRelationDescriptor($this->oldValue)
+            || self::isRelationDescriptor($this->newValue);
+    }
+
+    private static function isRelationDescriptor(mixed $value): bool
+    {
+        return \is_array($value)
+            && \array_key_exists('id', $value)
+            && \array_key_exists('class', $value)
+            && \array_key_exists('label', $value)
+            && \array_key_exists('table', $value);
+    }
+}

--- a/src/Model/AuditDiffCollection.php
+++ b/src/Model/AuditDiffCollection.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Model;
+
+use DH\Auditor\Tests\Model\AuditDiffCollectionTest;
+
+/**
+ * Typed, iterable collection of {@see AuditDiff} objects for a single audit entry.
+ *
+ * Built from the 'changes' map returned by Entry::getDiffs() internals.
+ * Non-array values (e.g. legacy REMOVE flat shape) are silently skipped so
+ * the collection is always safe to iterate.
+ *
+ * @implements \IteratorAggregate<int, AuditDiff>
+ *
+ * @see AuditDiffCollectionTest
+ */
+final class AuditDiffCollection implements \Countable, \IteratorAggregate
+{
+    /** @var list<AuditDiff> */
+    private array $diffs;
+
+    /**
+     * @param array<string, mixed> $changes Raw changes map from Entry::getDiffs() internals.
+     *                                      Each value should be an array with 'old' and/or 'new' keys.
+     *                                      Non-array values are silently skipped (legacy REMOVE shape).
+     */
+    public function __construct(array $changes)
+    {
+        $this->diffs = [];
+
+        foreach ($changes as $field => $change) {
+            // Non-array values are legacy REMOVE flat shape (id, class, label, table as strings).
+            if (!\is_array($change)) {
+                continue;
+            }
+
+            $old = \array_key_exists('old', $change) ? $change['old'] : null;
+            $new = \array_key_exists('new', $change) ? $change['new'] : null;
+
+            $this->diffs[] = new AuditDiff((string) $field, $old, $new);
+        }
+    }
+
+    /** @return \ArrayIterator<int, AuditDiff> */
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->diffs);
+    }
+
+    public function count(): int
+    {
+        return \count($this->diffs);
+    }
+
+    /**
+     * Returns the diff for the given field name, or null if not present.
+     */
+    public function getField(string $field): ?AuditDiff
+    {
+        foreach ($this->diffs as $diff) {
+            if ($diff->getField() === $field) {
+                return $diff;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns a new collection containing only fields that were added (old === null, new !== null).
+     */
+    public function added(): self
+    {
+        return self::fromDiffs(array_values(array_filter(
+            $this->diffs,
+            static fn (AuditDiff $d): bool => $d->wasAdded(),
+        )));
+    }
+
+    /**
+     * Returns a new collection containing only fields that were removed (old !== null, new === null).
+     */
+    public function removed(): self
+    {
+        return self::fromDiffs(array_values(array_filter(
+            $this->diffs,
+            static fn (AuditDiff $d): bool => $d->wasRemoved(),
+        )));
+    }
+
+    /**
+     * Returns a new collection containing only fields that were changed (both old and new are set).
+     */
+    public function changed(): self
+    {
+        return self::fromDiffs(array_values(array_filter(
+            $this->diffs,
+            static fn (AuditDiff $d): bool => !$d->wasAdded() && !$d->wasRemoved(),
+        )));
+    }
+
+    /** @param list<AuditDiff> $diffs */
+    private static function fromDiffs(array $diffs): self
+    {
+        $instance = new self([]);
+        $instance->diffs = $diffs;
+
+        return $instance;
+    }
+}

--- a/src/Model/AuditDiffCollection.php
+++ b/src/Model/AuditDiffCollection.php
@@ -10,8 +10,8 @@ use DH\Auditor\Tests\Model\AuditDiffCollectionTest;
  * Typed, iterable collection of {@see AuditDiff} objects for a single audit entry.
  *
  * Built from the 'changes' map returned by Entry::getDiffs() internals.
- * Non-array values (e.g. legacy REMOVE flat shape) are silently skipped so
- * the collection is always safe to iterate.
+ * Non-array values (e.g. legacy REMOVE flat shape) are skipped so the collection
+ * is always safe to iterate — use Entry::getDiffsAsArray() to access the raw descriptor.
  *
  * @implements \IteratorAggregate<int, AuditDiff>
  *
@@ -92,13 +92,16 @@ final class AuditDiffCollection implements \Countable, \IteratorAggregate
     }
 
     /**
-     * Returns a new collection containing only fields that were changed (both old and new are set).
+     * Returns a new collection containing only fields that were changed (old !== null and new !== null).
+     *
+     * Diffs where both old and new are null are excluded — a field with no before and no after
+     * value is not a meaningful change.
      */
     public function changed(): self
     {
         return self::fromDiffs(array_values(array_filter(
             $this->diffs,
-            static fn (AuditDiff $d): bool => !$d->wasAdded() && !$d->wasRemoved(),
+            static fn (AuditDiff $d): bool => null !== $d->getOldValue() && null !== $d->getNewValue(),
         )));
     }
 

--- a/src/Model/Entry.php
+++ b/src/Model/Entry.php
@@ -84,21 +84,56 @@ final class Entry
     private ?\DateTimeImmutable $created_at = null;
 
     /**
-     * Get diff changes for the current entry.
+     * Returns a typed collection of {@see AuditDiff} objects for this entry.
      *
-     * For entries written with schema_version >= 2 (new unified format), returns
-     * the 'changes' sub-array: ['field' => ['old' => x, 'new' => y], ...].
+     * For schema_version >= 2 entries, iterates over the unified 'changes' map
+     * (field => {old, new}). ASSOCIATE/DISSOCIATE entries have no 'changes' key
+     * and return an empty collection; use getDiffSource() / getDiffTarget() instead.
      *
-     * For legacy entries (schema_version = 1, old format), returns the raw decoded
-     * diffs array as-is so that existing consumers continue to work unchanged.
+     * For legacy entries (schema_version = 1), builds the collection from the raw
+     * decoded diffs array. Non-array values (legacy REMOVE flat shape) are silently
+     * skipped, yielding an empty collection for those entries.
+     *
+     * Use getDiffsAsArray() to retrieve the raw array in the legacy format.
      */
-    public function getDiffs(): array
+    public function getDiffs(): AuditDiffCollection
     {
         $diffs = $this->decodeJson($this->diffs);
 
         if ($this->schemaVersion >= 2) {
-            // Association/dissociation entries have no 'changes' key — return the full diff
-            // (source, target, is_owning_side, join_table) so consumers can inspect it uniformly.
+            // ASSOCIATE/DISSOCIATE: no 'changes' key — return empty collection.
+            // Use getDiffSource() / getDiffTarget() to inspect the relation descriptors.
+            if (!\array_key_exists('changes', $diffs)) {
+                return new AuditDiffCollection([]);
+            }
+
+            $changes = \is_array($diffs['changes']) ? $diffs['changes'] : [];
+
+            return new AuditDiffCollection($this->sort($changes));
+        }
+
+        // Legacy format (schema_version = 1): strip @source and build collection.
+        // Non-array values (legacy REMOVE shape) are skipped by AuditDiffCollection.
+        unset($diffs['@source']);
+
+        return new AuditDiffCollection($this->sort($diffs));
+    }
+
+    /**
+     * Returns the raw diff array, preserving the legacy array format.
+     *
+     * For schema_version >= 2: returns the 'changes' sub-array (field => {old, new}).
+     * For legacy entries (schema_version = 1): returns the raw decoded diffs array.
+     * For ASSOCIATE/DISSOCIATE (schema_version >= 2): returns the full diff envelope.
+     *
+     * Use this as an escape hatch when array access is required (e.g. Twig templates,
+     * serialization). Prefer getDiffs() for typed access in PHP code.
+     */
+    public function getDiffsAsArray(): array
+    {
+        $diffs = $this->decodeJson($this->diffs);
+
+        if ($this->schemaVersion >= 2) {
             if (!\array_key_exists('changes', $diffs)) {
                 return $this->sort($diffs);
             }
@@ -108,7 +143,6 @@ final class Entry
             return $this->sort($changes);
         }
 
-        // Legacy format (schema_version = 1): return raw array, stripping @source metadata
         unset($diffs['@source']);
 
         return $this->sort($diffs);
@@ -247,6 +281,10 @@ final class Entry
     /**
      * Recursively sorts an array by key, preserving the old-before-new insertion order for
      * 'old'/'new' diff leaf pairs, but still recursively sorting any array values within them.
+     *
+     * @param array<array-key, mixed> $array
+     *
+     * @return array<string, mixed>
      */
     private function sort(array $array): array
     {

--- a/src/Model/Entry.php
+++ b/src/Model/Entry.php
@@ -90,11 +90,15 @@ final class Entry
      * (field => {old, new}). ASSOCIATE/DISSOCIATE entries have no 'changes' key
      * and return an empty collection; use getDiffSource() / getDiffTarget() instead.
      *
-     * For legacy entries (schema_version = 1), builds the collection from the raw
-     * decoded diffs array. Non-array values (legacy REMOVE flat shape) are silently
-     * skipped, yielding an empty collection for those entries.
+     * For schema_version = 1 REMOVE entries, the diffs JSON contains a flat entity
+     * descriptor (id, class, label, table) rather than field-level changes, which
+     * yields an empty collection. Use getDiffsAsArray() to access the raw descriptor,
+     * or check $entry->type === TransactionType::REMOVE->value before calling getDiffs().
      *
-     * Use getDiffsAsArray() to retrieve the raw array in the legacy format.
+     * For other schema_version = 1 entries (INSERT/UPDATE), returns the field changes
+     * with old defaulting to null for INSERT (no 'old' key in legacy format).
+     *
+     * Use getDiffsAsArray() as an escape hatch when a raw array is required.
      */
     public function getDiffs(): AuditDiffCollection
     {
@@ -107,9 +111,15 @@ final class Entry
                 return new AuditDiffCollection([]);
             }
 
-            $changes = \is_array($diffs['changes']) ? $diffs['changes'] : [];
+            if (!\is_array($diffs['changes'])) {
+                throw new \UnexpectedValueException(\sprintf(
+                    'Entry #%d: expected array for "changes" key in diffs JSON, got %s.',
+                    $this->id ?? 0,
+                    get_debug_type($diffs['changes']),
+                ));
+            }
 
-            return new AuditDiffCollection($this->sort($changes));
+            return new AuditDiffCollection($this->sort($diffs['changes']));
         }
 
         // Legacy format (schema_version = 1): strip @source and build collection.
@@ -138,9 +148,15 @@ final class Entry
                 return $this->sort($diffs);
             }
 
-            $changes = \is_array($diffs['changes']) ? $diffs['changes'] : [];
+            if (!\is_array($diffs['changes'])) {
+                throw new \UnexpectedValueException(\sprintf(
+                    'Entry #%d: expected array for "changes" key in diffs JSON, got %s.',
+                    $this->id ?? 0,
+                    get_debug_type($diffs['changes']),
+                ));
+            }
 
-            return $this->sort($changes);
+            return $this->sort($diffs['changes']);
         }
 
         unset($diffs['@source']);

--- a/tests/Model/AuditDiffCollectionTest.php
+++ b/tests/Model/AuditDiffCollectionTest.php
@@ -138,6 +138,34 @@ final class AuditDiffCollectionTest extends TestCase
         $this->assertCount(0, $collection);
     }
 
+    public function testChangedExcludesNullNullDiff(): void
+    {
+        // A diff where both old and new are null is neither added nor removed nor changed.
+        $collection = new AuditDiffCollection([
+            'ghost' => ['old' => null, 'new' => null],
+            'name' => ['old' => 'Alice', 'new' => 'Bob'],
+        ]);
+
+        $this->assertCount(1, $collection->changed());
+        $this->assertNull($collection->changed()->getField('ghost'));
+        $this->assertNotNull($collection->changed()->getField('name'));
+        $this->assertCount(0, $collection->added());
+        $this->assertCount(0, $collection->removed());
+    }
+
+    public function testMixedSkippedAndValidEntries(): void
+    {
+        // Legacy REMOVE flat shape mixed with a valid field diff: only the valid one is counted
+        $collection = new AuditDiffCollection([
+            'id' => '1',           // scalar — skipped
+            'class' => 'App\Foo',  // scalar — skipped
+            'name' => ['old' => 'Alice', 'new' => 'Bob'],
+        ]);
+
+        $this->assertCount(1, $collection);
+        $this->assertNotNull($collection->getField('name'));
+    }
+
     public function testFilteredCollectionIsIterable(): void
     {
         $collection = new AuditDiffCollection([

--- a/tests/Model/AuditDiffCollectionTest.php
+++ b/tests/Model/AuditDiffCollectionTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Tests\Model;
+
+use DH\Auditor\Model\AuditDiff;
+use DH\Auditor\Model\AuditDiffCollection;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[Small]
+final class AuditDiffCollectionTest extends TestCase
+{
+    public function testIsEmpty(): void
+    {
+        $collection = new AuditDiffCollection([]);
+
+        $this->assertCount(0, $collection);
+    }
+
+    public function testCount(): void
+    {
+        $collection = new AuditDiffCollection([
+            'email' => ['old' => 'a@a.com', 'new' => 'b@b.com'],
+            'name' => ['old' => 'Alice', 'new' => 'Bob'],
+        ]);
+
+        $this->assertCount(2, $collection);
+    }
+
+    public function testIsIterable(): void
+    {
+        $collection = new AuditDiffCollection([
+            'email' => ['old' => 'a@a.com', 'new' => 'b@b.com'],
+        ]);
+
+        foreach ($collection as $diff) {
+            $this->assertInstanceOf(AuditDiff::class, $diff);
+            $this->assertSame('email', $diff->getField());
+            $this->assertSame('a@a.com', $diff->getOldValue());
+            $this->assertSame('b@b.com', $diff->getNewValue());
+        }
+    }
+
+    public function testGetField(): void
+    {
+        $collection = new AuditDiffCollection([
+            'email' => ['old' => 'a@a.com', 'new' => 'b@b.com'],
+            'name' => ['old' => 'Alice', 'new' => 'Bob'],
+        ]);
+
+        $diff = $collection->getField('name');
+        $this->assertInstanceOf(AuditDiff::class, $diff);
+        $this->assertSame('name', $diff->getField());
+        $this->assertSame('Alice', $diff->getOldValue());
+        $this->assertSame('Bob', $diff->getNewValue());
+    }
+
+    public function testGetFieldReturnsNullWhenNotFound(): void
+    {
+        $collection = new AuditDiffCollection([
+            'email' => ['old' => 'a@a.com', 'new' => 'b@b.com'],
+        ]);
+
+        $this->assertNull($collection->getField('nonexistent'));
+    }
+
+    public function testAdded(): void
+    {
+        $collection = new AuditDiffCollection([
+            'email' => ['old' => null, 'new' => 'new@example.com'],    // added
+            'name' => ['old' => 'Alice', 'new' => 'Bob'],              // changed
+            'phone' => ['old' => '555-1234', 'new' => null],           // removed
+        ]);
+
+        $added = $collection->added();
+        $this->assertCount(1, $added);
+        $this->assertNotNull($added->getField('email'));
+        $this->assertNull($added->getField('name'));
+    }
+
+    public function testRemoved(): void
+    {
+        $collection = new AuditDiffCollection([
+            'email' => ['old' => null, 'new' => 'new@example.com'],    // added
+            'name' => ['old' => 'Alice', 'new' => 'Bob'],              // changed
+            'phone' => ['old' => '555-1234', 'new' => null],           // removed
+        ]);
+
+        $removed = $collection->removed();
+        $this->assertCount(1, $removed);
+        $this->assertNotNull($removed->getField('phone'));
+        $this->assertNull($removed->getField('name'));
+    }
+
+    public function testChanged(): void
+    {
+        $collection = new AuditDiffCollection([
+            'email' => ['old' => null, 'new' => 'new@example.com'],    // added
+            'name' => ['old' => 'Alice', 'new' => 'Bob'],              // changed
+            'phone' => ['old' => '555-1234', 'new' => null],           // removed
+        ]);
+
+        $changed = $collection->changed();
+        $this->assertCount(1, $changed);
+        $this->assertNotNull($changed->getField('name'));
+        $this->assertNull($changed->getField('email'));
+    }
+
+    public function testLegacyInsertWithoutOldKey(): void
+    {
+        // schema_version = 1 INSERT: no 'old' key — treated as added (old = null)
+        $collection = new AuditDiffCollection([
+            'name' => ['new' => 'Alice'],
+        ]);
+
+        $diff = $collection->getField('name');
+        $this->assertNotNull($diff);
+        $this->assertNull($diff->getOldValue());
+        $this->assertSame('Alice', $diff->getNewValue());
+        $this->assertTrue($diff->wasAdded());
+    }
+
+    public function testLegacyRemoveShapeYieldsEmptyCollection(): void
+    {
+        // schema_version = 1 REMOVE: flat {id, class, label, table} — not field-level diffs
+        $collection = new AuditDiffCollection([
+            'id' => '1',
+            'class' => 'App\Entity\Foo',
+            'label' => 'Foo label',
+            'table' => 'foo',
+        ]);
+
+        $this->assertCount(0, $collection);
+    }
+
+    public function testFilteredCollectionIsIterable(): void
+    {
+        $collection = new AuditDiffCollection([
+            'a' => ['old' => null, 'new' => 'x'],
+            'b' => ['old' => '1', 'new' => '2'],
+        ]);
+
+        $added = $collection->added();
+        $fields = [];
+        foreach ($added as $diff) {
+            $fields[] = $diff->getField();
+        }
+
+        $this->assertSame(['a'], $fields);
+    }
+}

--- a/tests/Model/AuditDiffTest.php
+++ b/tests/Model/AuditDiffTest.php
@@ -93,6 +93,19 @@ final class AuditDiffTest extends TestCase
         $diff = new AuditDiff('field', null, null);
 
         $this->assertFalse($diff->isRelation());
+        $this->assertFalse($diff->wasAdded());
+        $this->assertFalse($diff->wasRemoved());
+    }
+
+    public function testIsRelationWhenBothSidesAreRelationDescriptors(): void
+    {
+        $old = ['id' => '1', 'class' => 'App\Entity\Author', 'label' => 'Alice', 'table' => 'author'];
+        $new = ['id' => '2', 'class' => 'App\Entity\Author', 'label' => 'Bob', 'table' => 'author'];
+        $diff = new AuditDiff('author', $old, $new);
+
+        $this->assertTrue($diff->isRelation());
+        $this->assertFalse($diff->wasAdded());
+        $this->assertFalse($diff->wasRemoved());
     }
 
     public function testIsRelationIsFalseForIncompleteArray(): void

--- a/tests/Model/AuditDiffTest.php
+++ b/tests/Model/AuditDiffTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Auditor\Tests\Model;
+
+use DH\Auditor\Model\AuditDiff;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[Small]
+final class AuditDiffTest extends TestCase
+{
+    public function testGetField(): void
+    {
+        $diff = new AuditDiff('email', 'old@example.com', 'new@example.com');
+
+        $this->assertSame('email', $diff->getField());
+    }
+
+    public function testGetOldValue(): void
+    {
+        $diff = new AuditDiff('email', 'old@example.com', 'new@example.com');
+
+        $this->assertSame('old@example.com', $diff->getOldValue());
+    }
+
+    public function testGetNewValue(): void
+    {
+        $diff = new AuditDiff('email', 'old@example.com', 'new@example.com');
+
+        $this->assertSame('new@example.com', $diff->getNewValue());
+    }
+
+    public function testWasAdded(): void
+    {
+        $diff = new AuditDiff('email', null, 'new@example.com');
+
+        $this->assertTrue($diff->wasAdded());
+        $this->assertFalse($diff->wasRemoved());
+    }
+
+    public function testWasAddedIsFalseWhenBothValuesSet(): void
+    {
+        $diff = new AuditDiff('email', 'old@example.com', 'new@example.com');
+
+        $this->assertFalse($diff->wasAdded());
+    }
+
+    public function testWasRemoved(): void
+    {
+        $diff = new AuditDiff('email', 'old@example.com', null);
+
+        $this->assertTrue($diff->wasRemoved());
+        $this->assertFalse($diff->wasAdded());
+    }
+
+    public function testWasRemovedIsFalseWhenBothValuesSet(): void
+    {
+        $diff = new AuditDiff('email', 'old@example.com', 'new@example.com');
+
+        $this->assertFalse($diff->wasRemoved());
+    }
+
+    public function testIsRelationDetectsRelationInOldValue(): void
+    {
+        $relation = ['id' => '42', 'class' => 'App\Entity\Author', 'label' => 'Dark Vador', 'table' => 'author'];
+        $diff = new AuditDiff('author', $relation, null);
+
+        $this->assertTrue($diff->isRelation());
+    }
+
+    public function testIsRelationDetectsRelationInNewValue(): void
+    {
+        $relation = ['id' => '42', 'class' => 'App\Entity\Author', 'label' => 'Dark Vador', 'table' => 'author'];
+        $diff = new AuditDiff('author', null, $relation);
+
+        $this->assertTrue($diff->isRelation());
+    }
+
+    public function testIsRelationIsFalseForScalarValues(): void
+    {
+        $diff = new AuditDiff('email', 'old@example.com', 'new@example.com');
+
+        $this->assertFalse($diff->isRelation());
+    }
+
+    public function testIsRelationIsFalseForNullValues(): void
+    {
+        $diff = new AuditDiff('field', null, null);
+
+        $this->assertFalse($diff->isRelation());
+    }
+
+    public function testIsRelationIsFalseForIncompleteArray(): void
+    {
+        // Missing 'table' key — not a relation descriptor
+        $diff = new AuditDiff('field', ['id' => '1', 'class' => 'Foo', 'label' => 'bar'], null);
+
+        $this->assertFalse($diff->isRelation());
+    }
+}

--- a/tests/Model/EntryTest.php
+++ b/tests/Model/EntryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DH\Auditor\Tests\Model;
 
+use DH\Auditor\Model\AuditDiffCollection;
 use DH\Auditor\Model\Entry;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\TestCase;
@@ -40,7 +41,8 @@ final class EntryTest extends TestCase
         $this->assertSame(2, $entry->schemaVersion, 'Entry::schemaVersion is ok.');
         $this->assertSame('type', $entry->type, 'Entry::type is ok.');
         $this->assertSame('1', $entry->objectId, 'Entry::objectId is ok.');
-        $this->assertSame([], $entry->getDiffs(), 'Entry::getDiffs() returns empty array for empty diffs.');
+        $this->assertInstanceOf(AuditDiffCollection::class, $entry->getDiffs(), 'Entry::getDiffs() returns AuditDiffCollection.');
+        $this->assertCount(0, $entry->getDiffs(), 'Entry::getDiffs() returns empty collection for empty diffs.');
         $this->assertSame(1, $entry->userId, 'Entry::userId is ok.');
         $this->assertSame('John Doe', $entry->blame['username'], 'Entry::blame[username] is ok.');
         $this->assertSame('Acme\User', $entry->blame['user_fqdn'], 'Entry::blame[user_fqdn] is ok.');
@@ -66,7 +68,7 @@ final class EntryTest extends TestCase
 
     public function testGetDiffsLegacyFormat(): void
     {
-        // schema_version = 1: old format, returns raw decoded array (minus @source)
+        // schema_version = 1: old format, collection built from raw diffs (minus @source)
         $entry = Entry::fromArray([
             'schema_version' => 1,
             'diffs' => json_encode([
@@ -76,13 +78,14 @@ final class EntryTest extends TestCase
         ]);
 
         $diffs = $entry->getDiffs();
-        $this->assertArrayNotHasKey('@source', $diffs, 'getDiffs() strips @source in legacy format.');
-        $this->assertArrayHasKey('name', $diffs, 'getDiffs() returns field diffs in legacy format.');
+        $this->assertInstanceOf(AuditDiffCollection::class, $diffs);
+        $this->assertCount(1, $diffs, 'getDiffs() strips @source in legacy format.');
+        $this->assertNotNull($diffs->getField('name'), 'getDiffs() includes field diffs in legacy format.');
     }
 
     public function testGetDiffsNewFormat(): void
     {
-        // schema_version = 2: unified envelope, returns 'changes' sub-array
+        // schema_version = 2: unified envelope, collection built from 'changes' sub-array
         $entry = Entry::fromArray([
             'schema_version' => 2,
             'diffs' => json_encode([
@@ -94,6 +97,60 @@ final class EntryTest extends TestCase
         ]);
 
         $diffs = $entry->getDiffs();
+        $this->assertInstanceOf(AuditDiffCollection::class, $diffs);
+        $this->assertCount(1, $diffs);
+        $diff = $diffs->getField('name');
+        $this->assertNotNull($diff);
+        $this->assertSame('Alice', $diff->getOldValue());
+        $this->assertSame('Bob', $diff->getNewValue());
+    }
+
+    public function testGetDiffsReturnsEmptyCollectionForAssociation(): void
+    {
+        // ASSOCIATE/DISSOCIATE (schema_version >= 2): no 'changes' key → empty collection
+        $entry = Entry::fromArray([
+            'schema_version' => 2,
+            'diffs' => json_encode([
+                'source' => ['id' => '1', 'class' => 'App\Entity\Post', 'label' => 'Post', 'table' => 'post', 'field' => 'tags'],
+                'target' => ['id' => '5', 'class' => 'App\Entity\Tag', 'label' => 'php', 'table' => 'tag', 'field' => 'posts'],
+                'is_owning_side' => true,
+            ]),
+        ]);
+
+        $diffs = $entry->getDiffs();
+        $this->assertInstanceOf(AuditDiffCollection::class, $diffs);
+        $this->assertCount(0, $diffs, 'ASSOCIATE/DISSOCIATE entries yield empty AuditDiffCollection.');
+    }
+
+    public function testGetDiffsAsArrayLegacyFormat(): void
+    {
+        $entry = Entry::fromArray([
+            'schema_version' => 1,
+            'diffs' => json_encode([
+                '@source' => ['id' => 1, 'class' => 'App\Entity\Foo', 'label' => 'Foo', 'table' => 'foo'],
+                'name' => ['new' => 'Alice'],
+            ]),
+        ]);
+
+        $diffs = $entry->getDiffsAsArray();
+        $this->assertIsArray($diffs);
+        $this->assertArrayNotHasKey('@source', $diffs, 'getDiffsAsArray() strips @source in legacy format.');
+        $this->assertArrayHasKey('name', $diffs);
+    }
+
+    public function testGetDiffsAsArrayNewFormat(): void
+    {
+        $entry = Entry::fromArray([
+            'schema_version' => 2,
+            'diffs' => json_encode([
+                'source' => ['id' => '1', 'class' => 'App\Entity\Foo', 'label' => 'Foo', 'table' => 'foo'],
+                'changes' => [
+                    'name' => ['old' => 'Alice', 'new' => 'Bob'],
+                ],
+            ]),
+        ]);
+
+        $diffs = $entry->getDiffsAsArray();
         $this->assertSame(['name' => ['old' => 'Alice', 'new' => 'Bob']], $diffs);
     }
 
@@ -144,11 +201,11 @@ final class EntryTest extends TestCase
         $this->assertNull($entry->getDiffTarget());
     }
 
-    public function testGetDiffsReturnsAnArray(): void
+    public function testGetDiffsReturnsCollection(): void
     {
         $entry = Entry::fromArray(['diffs' => '{}']);
 
-        $this->assertIsArray($entry->getDiffs(), 'Entry::getDiffs() returns an array.');
+        $this->assertInstanceOf(AuditDiffCollection::class, $entry->getDiffs(), 'Entry::getDiffs() returns AuditDiffCollection.');
     }
 
     public function testGetExtraDataReturnsNullWhenEmpty(): void

--- a/tests/Model/EntryTest.php
+++ b/tests/Model/EntryTest.php
@@ -154,6 +154,26 @@ final class EntryTest extends TestCase
         $this->assertSame(['name' => ['old' => 'Alice', 'new' => 'Bob']], $diffs);
     }
 
+    public function testGetDiffsAsArrayReturnsFullEnvelopeForAssociation(): void
+    {
+        // ASSOCIATE/DISSOCIATE (schema_version >= 2, no 'changes' key): getDiffsAsArray() must
+        // return the full diffs envelope so consumers can inspect source/target/is_owning_side.
+        $entry = Entry::fromArray([
+            'schema_version' => 2,
+            'diffs' => json_encode([
+                'source' => ['id' => '1', 'class' => 'App\Entity\Post', 'label' => 'Post', 'table' => 'post'],
+                'target' => ['id' => '5', 'class' => 'App\Entity\Tag', 'label' => 'php', 'table' => 'tag'],
+                'is_owning_side' => true,
+            ]),
+        ]);
+
+        $array = $entry->getDiffsAsArray();
+        $this->assertIsArray($array);
+        $this->assertArrayHasKey('source', $array);
+        $this->assertArrayHasKey('target', $array);
+        $this->assertArrayHasKey('is_owning_side', $array);
+    }
+
     public function testGetDiffSource(): void
     {
         $entry = Entry::fromArray([


### PR DESCRIPTION
## Summary

- `Entry::getDiffs()` now returns a typed `AuditDiffCollection` instead of a plain `array`, providing IDE completion and domain-level filtering helpers
- New `AuditDiff` immutable value object exposes `getField()`, `getOldValue()`, `getNewValue()`, `wasAdded()`, `wasRemoved()`, `isRelation()`
- New `AuditDiffCollection` implements `IteratorAggregate + Countable` with `getField()`, `added()`, `removed()`, `changed()` sub-collection filters
- `Entry::getDiffsAsArray()` added as an explicit escape hatch for Twig templates and serialization (preserves previous `getDiffs()` array behaviour)
- ASSOCIATE/DISSOCIATE entries yield an empty collection; callers use `getDiffSource()` / `getDiffTarget()` for the relation descriptors

## BC impact

`Entry::getDiffs()` return type changes from `array` to `AuditDiffCollection`. Callers expecting `array` must migrate to `getDiffsAsArray()` or iterate the collection directly.

## Test plan

- [ ] `composer agent-test` passes (88 tests, 182 assertions)
- [ ] `composer agent-phpstan` clean at level max
- [ ] `AuditDiffTest` — field access, wasAdded/wasRemoved, isRelation (both sides, one side, null/null)
- [ ] `AuditDiffCollectionTest` — count, iteration, getField, added/removed/changed filters, null/null exclusion from changed(), legacy REMOVE flat shape, mixed skipped entries
- [ ] `EntryTest` — getDiffs() returns AuditDiffCollection for all schema versions, getDiffsAsArray() for all schema versions including ASSOCIATE/DISSOCIATE full envelope