### PR TITLE
feat: add Entry::toArray() for structured export serialization

### DIFF
--- a/src/Model/Entry.php
+++ b/src/Model/Entry.php
@@ -149,6 +149,33 @@ final class Entry
         return \is_array($target) ? $target : null;
     }
 
+    /**
+     * Returns a flat associative array suitable for CSV/JSON/NDJSON export.
+     * Blame fields are expanded from the unified blame structure for consistent output
+     * regardless of schema version.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'schema_version' => $this->schemaVersion,
+            'type' => $this->type,
+            'object_id' => $this->objectId,
+            'discriminator' => $this->discriminator,
+            'transaction_id' => $this->transactionId,
+            'diffs' => $this->getDiffs(),
+            'blame_id' => $this->userId,
+            'blame_user' => $this->username,
+            'blame_user_fqdn' => $this->userFqdn,
+            'blame_user_firewall' => $this->userFirewall,
+            'ip' => $this->ip,
+            'extra_data' => $this->extraData,
+            'created_at' => $this->createdAt?->format(\DateTimeInterface::ATOM),
+        ];
+    }
+
     public function getExtraData(): ?array
     {
         if (null === $this->extra_data) {

--- a/tests/Model/EntryTest.php
+++ b/tests/Model/EntryTest.php
@@ -189,6 +189,91 @@ final class EntryTest extends TestCase
         $this->assertNull($entry->transactionId);
     }
 
+    public function testToArrayHasExpectedKeys(): void
+    {
+        $entry = new Entry();
+        $data = $entry->toArray();
+
+        $expected = ['id', 'schema_version', 'type', 'object_id', 'discriminator', 'transaction_id', 'diffs', 'blame_id', 'blame_user', 'blame_user_fqdn', 'blame_user_firewall', 'ip', 'extra_data', 'created_at'];
+        $this->assertSame($expected, array_keys($data));
+    }
+
+    public function testToArrayV2Entry(): void
+    {
+        $createdAt = new \DateTimeImmutable('2025-01-15T10:00:00+00:00');
+        $blame = json_encode(['username' => 'john', 'user_fqdn' => 'App\User', 'user_firewall' => 'main', 'ip' => '1.2.3.4']);
+        $diffs = json_encode(['source' => ['id' => '1', 'class' => 'App\Entity\Foo', 'label' => 'Foo', 'table' => 'foo'], 'changes' => ['name' => ['old' => 'Alice', 'new' => 'Bob']]]);
+
+        $entry = Entry::fromArray([
+            'id' => 7,
+            'schema_version' => 2,
+            'type' => 'update',
+            'object_id' => '99',
+            'discriminator' => null,
+            'transaction_id' => '01HXYZ1234567890ABCDEFGHIJ',
+            'diffs' => $diffs,
+            'blame_id' => 42,
+            'blame' => $blame,
+            'extra_data' => '{"source":"api"}',
+            'created_at' => $createdAt,
+        ]);
+
+        $data = $entry->toArray();
+
+        $this->assertSame(7, $data['id']);
+        $this->assertSame(2, $data['schema_version']);
+        $this->assertSame('update', $data['type']);
+        $this->assertSame('99', $data['object_id']);
+        $this->assertSame('01HXYZ1234567890ABCDEFGHIJ', $data['transaction_id']);
+        $this->assertSame(['name' => ['old' => 'Alice', 'new' => 'Bob']], $data['diffs']);
+        $this->assertSame(42, $data['blame_id']);
+        $this->assertSame('john', $data['blame_user']);
+        $this->assertSame('App\User', $data['blame_user_fqdn']);
+        $this->assertSame('main', $data['blame_user_firewall']);
+        $this->assertSame('1.2.3.4', $data['ip']);
+        $this->assertSame(['source' => 'api'], $data['extra_data']);
+        $this->assertSame($createdAt->format(\DateTimeInterface::ATOM), $data['created_at']);
+    }
+
+    public function testToArrayV1LegacyEntry(): void
+    {
+        $entry = Entry::fromArray([
+            'id' => 3,
+            'schema_version' => 1,
+            'type' => 'insert',
+            'object_id' => '5',
+            'blame_id' => 'user@example.com',
+            'blame_user' => 'Jane',
+            'blame_user_fqdn' => 'App\Entity\User',
+            'blame_user_firewall' => 'api',
+            'ip' => '10.0.0.1',
+            'diffs' => '{}',
+        ]);
+
+        $data = $entry->toArray();
+
+        $this->assertSame('user@example.com', $data['blame_id']);
+        $this->assertSame('Jane', $data['blame_user']);
+        $this->assertSame('App\Entity\User', $data['blame_user_fqdn']);
+        $this->assertSame('api', $data['blame_user_firewall']);
+        $this->assertSame('10.0.0.1', $data['ip']);
+    }
+
+    public function testToArrayCreatedAtIsAtomFormattedString(): void
+    {
+        $createdAt = new \DateTimeImmutable('2025-06-01T12:30:00+02:00');
+        $entry = Entry::fromArray(['created_at' => $createdAt]);
+
+        $this->assertSame($createdAt->format(\DateTimeInterface::ATOM), $entry->toArray()['created_at']);
+    }
+
+    public function testToArrayCreatedAtIsNullWhenNotSet(): void
+    {
+        $entry = new Entry();
+
+        $this->assertNull($entry->toArray()['created_at']);
+    }
+
     public function testFromArrayWithLegacyV1Row(): void
     {
         // Simulate a SELECT * row from a v1 table (or a transitional table with both


### PR DESCRIPTION
## Summary

- Add `Entry::toArray(): array` to serialize an audit entry into a plain associative array, normalizing dates to ISO 8601 and exposing the same keys regardless of schema version (v1 or v2)
- Used by the `audit:export` CLI command (auditor-doctrine-provider) and the HTTP export endpoint (auditor-bundle) to produce uniform NDJSON, JSON, and CSV output
- Backed by 5 new unit tests covering all fields, date formatting, and null handling

## Test plan

- [ ] `composer agent-test` passes in `auditor` core
- [ ] `Entry::toArray()` returns expected keys for both v1 and v2 schema rows
- [ ] Dependent packages (`auditor-doctrine-provider`, `auditor-bundle`) use this to drive their export output