### PR TITLE
feat: add maxAge and maxEntries retention params to #[Auditable]

### DIFF
--- a/src/Attribute/Auditable.php
+++ b/src/Attribute/Auditable.php
@@ -7,5 +7,9 @@ namespace DH\Auditor\Attribute;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class Auditable
 {
-    public function __construct(public bool $enabled = true) {}
+    public function __construct(
+        public bool $enabled = true,
+        public ?string $maxAge = null,
+        public ?int $maxEntries = null,
+    ) {}
 }


### PR DESCRIPTION
## Summary

- Extends `#[Auditable]` with two optional constructor parameters:
  - `maxAge: ?string` — ISO 8601 duration (e.g. `'P7Y'`, `'P30D'`) for per-entity age-based retention
  - `maxEntries: ?int` — per-entity count-based retention (keep only the N most recent audit rows)
- These values are read by `AttributeLoader` in `auditor-doctrine-provider` and exposed as `max_age` / `max_entries` in the entity configuration array, where `audit:clean` consumes them

Part of auditor-private#18 (audit retention & pruning — phase 1).

Companion PR: `auditor-doctrine-provider` `feature/audit-retention`

## Test plan

- [ ] `composer agent-test` passes (58 tests)
- [ ] `composer agent-phpstan` passes (level max)
- [ ] `composer agent-cs-fix` produces no changes